### PR TITLE
DM-14690: Add ability to construct centered boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _build.*
 *.cfgc
 *.pyc
 .cache
+.coverage
 .pytest_cache
 pytest_session.txt
 config.log

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -106,6 +106,18 @@ public:
     Box2I(Box2I&&) = default;
     ~Box2I() = default;
 
+    /**
+     * Create a box centered as closely as possible on a particular point.
+     *
+     * @param center The desired center of the box.
+     * @param size The desired width and height (in that order) of the box.
+     *
+     * @returns if `size` is positive, a box with size `size`; otherwise,
+     *          an empty box. If the returned box is not empty, its center
+     *          shall be within half a pixel of `center` in either dimension.
+     */
+    static Box2I makeCenteredBox(Point2D const& center, Extent const& size);
+
     void swap(Box2I& other) {
         _minimum.swap(other._minimum);
         _dimensions.swap(other._dimensions);
@@ -322,6 +334,18 @@ public:
     Box2D(Box2D&&) = default;
 
     ~Box2D() = default;
+
+    /**
+     * Create a box centered on a particular point.
+     *
+     * @param center The desired center of the box.
+     * @param size The desired width and height (in that order) of the box.
+     *
+     * @returns if `size` is positive, a box with size `size`; otherwise,
+     *          an empty box. If the returned box is not empty, it shall be
+     *          centered on `center`.
+     */
+    static Box2D makeCenteredBox(Point2D const& center, Extent const& size);
 
     void swap(Box2D& other) {
         _minimum.swap(other._minimum);

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -73,14 +73,16 @@ public:
     Box2I(Point2I const& minimum, Point2I const& maximum, bool invert = true);
 
     /**
-     *  Construct a box from its minimum point and dimensions.
+     *  Construct a box from one corner and dimensions.
      *
-     *  @param[in] minimum    Minimum (lower left) coordinate.
+     *  @param[in] corner    Reference coordinate. This is the lower left corner if both
+     *                       dimensions are positive, but a right corner or upper corner if
+     *                       the corresponding dimension is negative and `invert` is set.
      *  @param[in] dimensions Box dimensions.  If either dimension coordinate is 0, the box will be empty.
      *  @param[in] invert     If true (default), invert any negative dimensions instead of creating
      *                        an empty box.
      */
-    Box2I(Point2I const& minimum, Extent2I const& dimensions, bool invert = true);
+    Box2I(Point2I const& corner, Extent2I const& dimensions, bool invert = true);
 
     /**
      *  Construct an integer box from a floating-point box.
@@ -293,14 +295,16 @@ public:
     Box2D(Point2D const& minimum, Point2D const& maximum, bool invert = true);
 
     /**
-     *  Construct a box from its minimum point and dimensions.
+     *  Construct a box from one corner and dimensions.
      *
-     *  @param[in] minimum    Minimum (lower left) coordinate (inclusive).
+     *  @param[in] corner    Reference coordinate (inclusive). This is the lower left corner if
+     *                       both dimensions are positive, but a right corner or upper corner if
+     *                       the corresponding dimension is negative and `invert` is set.
      *  @param[in] dimensions Box dimensions.  If either dimension coordinate is 0, the box will be empty.
      *  @param[in] invert     If true (default), invert any negative dimensions instead of creating
      *                        an empty box.
      */
-    Box2D(Point2D const& minimum, Extent2D const& dimensions, bool invert = true);
+    Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert = true);
 
     /**
      *  Construct a floating-point box from an integer box.

--- a/python/lsst/geom/box.cc
+++ b/python/lsst/geom/box.cc
@@ -54,7 +54,7 @@ PYBIND11_PLUGIN(box) {
     clsBox2I.def(py::init<>());
     clsBox2I.def(py::init<Point2I const &, Point2I const &, bool>(), "minimum"_a, "maximum"_a,
                  "invert"_a = true);
-    clsBox2I.def(py::init<Point2I const &, Extent2I const &, bool>(), "minimum"_a, "dimensions"_a,
+    clsBox2I.def(py::init<Point2I const &, Extent2I const &, bool>(), "corner"_a, "dimensions"_a,
                  "invert"_a = true);
     clsBox2I.def(py::init<Box2D const &, Box2I::EdgeHandlingEnum>(), "other"_a,
                  "edgeHandling"_a = Box2I::EXPAND);
@@ -127,7 +127,7 @@ PYBIND11_PLUGIN(box) {
     clsBox2D.def(py::init<>());
     clsBox2D.def(py::init<Point2D const &, Point2D const &, bool>(), "minimum"_a, "maximum"_a,
                  "invert"_a = true);
-    clsBox2D.def(py::init<Point2D const &, Extent2D const &, bool>(), "minimum"_a, "dimensions"_a,
+    clsBox2D.def(py::init<Point2D const &, Extent2D const &, bool>(), "corner"_a, "dimensions"_a,
                  "invert"_a = true);
     clsBox2D.def(py::init<Box2I const &>());
     clsBox2D.def(py::init<Box2D const &>());

--- a/python/lsst/geom/box.cc
+++ b/python/lsst/geom/box.cc
@@ -65,6 +65,7 @@ PYBIND11_PLUGIN(box) {
     clsBox2I.def("__ne__", [](Box2I const &self, Box2I const &other) { return self != other; },
                  py::is_operator());
 
+    clsBox2I.def_static("makeCenteredBox", &Box2I::makeCenteredBox, "center"_a, "size"_a);
     clsBox2I.def("swap", &Box2I::swap);
     clsBox2I.def("getMin", &Box2I::getMin);
     clsBox2I.def("getMinX", &Box2I::getMinX);
@@ -137,6 +138,7 @@ PYBIND11_PLUGIN(box) {
     clsBox2D.def("__ne__", [](Box2D const &self, Box2D const &other) { return self != other; },
                  py::is_operator());
 
+    clsBox2D.def_static("makeCenteredBox", &Box2D::makeCenteredBox, "center"_a, "size"_a);
     clsBox2D.def("swap", &Box2D::swap);
     clsBox2D.def("getMin", &Box2D::getMin);
     clsBox2D.def("getMinX", &Box2D::getMinX);

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -43,8 +43,8 @@ Box2I::Box2I(Point2I const& minimum, Point2I const& maximum, bool invert)
     _dimensions += Extent2I(1);
 }
 
-Box2I::Box2I(Point2I const& minimum, Extent2I const& dimensions, bool invert)
-        : _minimum(minimum), _dimensions(dimensions) {
+Box2I::Box2I(Point2I const& corner, Extent2I const& dimensions, bool invert)
+        : _minimum(corner), _dimensions(dimensions) {
     for (int n = 0; n < 2; ++n) {
         if (_dimensions[n] == 0) {
             *this = Box2I();
@@ -238,8 +238,8 @@ Box2D::Box2D(Point2D const& minimum, Point2D const& maximum, bool invert)
     }
 }
 
-Box2D::Box2D(Point2D const& minimum, Extent2D const& dimensions, bool invert)
-        : _minimum(minimum), _maximum(minimum + dimensions) {
+Box2D::Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert)
+        : _minimum(corner), _maximum(corner + dimensions) {
     for (int n = 0; n < 2; ++n) {
         if (_minimum[n] == _maximum[n]) {
             *this = Box2D();

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -92,6 +92,14 @@ Box2I::Box2I(Box2D const& other, EdgeHandlingEnum edgeHandling) : _minimum(), _d
     }
 }
 
+Box2I Box2I::makeCenteredBox(Point2D const& center, Box2I::Extent const& size) {
+    lsst::geom::Point2D corner(center);
+    corner.shift(-0.5 * lsst::geom::Extent2D(size));
+    // compensate for Box2I's coordinate conventions (where max = min + size - 1)
+    corner.shift(lsst::geom::Extent2D(0.5, 0.5));
+    return lsst::geom::Box2I(lsst::geom::Point2I(corner), size, false);
+}
+
 ndarray::View<boost::fusion::vector2<ndarray::index::Range, ndarray::index::Range> > Box2I::getSlices()
         const {
     return ndarray::view(getBeginY(), getEndY())(getBeginX(), getEndX());
@@ -259,6 +267,12 @@ Box2D::Box2D(Box2I const& other)
         : _minimum(Point2D(other.getMin()) - Extent2D(0.5)),
           _maximum(Point2D(other.getMax()) + Extent2D(0.5)) {
     if (other.isEmpty()) *this = Box2D();
+}
+
+Box2D Box2D::makeCenteredBox(Point2D const& center, Box2D::Extent const& size) {
+    lsst::geom::Point2D corner(center);
+    corner.shift(-0.5 * size);
+    return lsst::geom::Box2D(corner, size, false);
 }
 
 bool Box2D::contains(Point2D const& point) const {


### PR DESCRIPTION
This PR adds factory methods to `Box2*` that create a box centered on a (fractional) point. In the process of debugging the implementation, I discovered that the behavior of one of the `Box` constructors is more complex than documented, and updated the documentation to match the existing behavior.

The renaming of the `Box2*` constructors' first parameter from `minimum` to `corner` does not seem to have broken any keyword-based code in `lsst_distrib`.