### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/geom/AffineTransform.h
+++ b/include/lsst/geom/AffineTransform.h
@@ -81,35 +81,36 @@ public:
     typedef Eigen::Matrix<double, 2, 6> TransformDerivativeMatrix;
 
     /** Construct an empty (identity) AffineTransform. */
-    AffineTransform() : _linear(), _translation() {}
+    AffineTransform() noexcept : _linear(), _translation() {}
 
     /** Construct an AffineTransform from a 3x3 matrix. */
-    explicit AffineTransform(Eigen::Matrix3d const &matrix)
+    explicit AffineTransform(Eigen::Matrix3d const &matrix) noexcept
             : _linear(matrix.block<2, 2>(0, 0)), _translation(matrix.block<2, 1>(0, 2)) {}
 
     /** Construct an AffineTransform with no translation from a 2x2 matrix. */
-    explicit AffineTransform(Eigen::Matrix2d const &linear) : _linear(linear), _translation() {}
+    explicit AffineTransform(Eigen::Matrix2d const &linear) noexcept : _linear(linear), _translation() {}
 
     /** Construct a translation-only AffineTransform from a vector. */
-    explicit AffineTransform(Eigen::Vector2d const &translation) : _linear(), _translation(translation) {}
+    explicit AffineTransform(Eigen::Vector2d const &translation) noexcept
+            : _linear(), _translation(translation) {}
 
     /** Construct an AffineTransform from a 2x2 matrix and vector. */
-    explicit AffineTransform(Eigen::Matrix2d const &linear, Eigen::Vector2d const &translation)
+    explicit AffineTransform(Eigen::Matrix2d const &linear, Eigen::Vector2d const &translation) noexcept
             : _linear(linear), _translation(translation) {}
 
     /** Construct an AffineTransform from a LinearTransform. */
-    AffineTransform(LinearTransform const &linear) : _linear(linear), _translation() {}
+    AffineTransform(LinearTransform const &linear) noexcept : _linear(linear), _translation() {}
 
     /** Construct a translation-only AffineTransform from an Extent2D. */
-    explicit AffineTransform(Extent2D const &translation) : _linear(), _translation(translation) {}
+    explicit AffineTransform(Extent2D const &translation) noexcept : _linear(), _translation(translation) {}
 
     /** Construct an AffineTransform from a LinearTransform and Extent2D. */
-    explicit AffineTransform(LinearTransform const &linear, Extent2D const &translation)
+    explicit AffineTransform(LinearTransform const &linear, Extent2D const &translation) noexcept
             : _linear(linear), _translation(translation) {}
 
-    AffineTransform(AffineTransform const &) = default;
-    AffineTransform(AffineTransform &&) = default;
-    ~AffineTransform() = default;
+    AffineTransform(AffineTransform const &) noexcept = default;
+    AffineTransform(AffineTransform &&) noexcept = default;
+    ~AffineTransform() noexcept = default;
 
     /**
      * Return the inverse transform
@@ -119,45 +120,45 @@ public:
     AffineTransform const invert() const;
 
     /** Whether the transform is a no-op. */
-    bool isIdentity() const { return getMatrix().isIdentity(); }
+    bool isIdentity() const noexcept { return getMatrix().isIdentity(); }
 
     /**
      * Transform a Point object.
      *
      * The result is affected by the translation parameters of the transform
      */
-    Point2D operator()(Point2D const &p) const { return Point2D(_linear(p) + _translation); }
+    Point2D operator()(Point2D const &p) const noexcept { return Point2D(_linear(p) + _translation); }
 
     /**
      * Transform an Extent object.
      *
      * The result is unaffected by the translation parameters of the transform
      */
-    Extent2D operator()(Extent2D const &p) const { return Extent2D(_linear(p)); }
+    Extent2D operator()(Extent2D const &p) const noexcept { return Extent2D(_linear(p)); }
 
-    Extent2D const &getTranslation() const { return _translation; }
-    Extent2D &getTranslation() { return _translation; }
+    Extent2D const &getTranslation() const noexcept { return _translation; }
+    Extent2D &getTranslation() noexcept { return _translation; }
 
-    LinearTransform const &getLinear() const { return _linear; }
-    LinearTransform &getLinear() { return _linear; }
+    LinearTransform const &getLinear() const noexcept { return _linear; }
+    LinearTransform &getLinear() noexcept { return _linear; }
 
     /**
      * Return the transform as a full 3x3 matrix
      */
-    Matrix const getMatrix() const;
+    Matrix const getMatrix() const noexcept;
 
     /**
      * Return the transform matrix elements as a parameter vector
      *
      * The elements will be ordered XX, YX, XY, YY, X, Y
      */
-    ParameterVector const getParameterVector() const;
+    ParameterVector const getParameterVector() const noexcept;
     /**
      * Set the transform matrix elements from a parameter vector
      *
      * The parameter vector is ordered XX, YX, XY, YY, X, Y
      */
-    void setParameterVector(ParameterVector const &vector);
+    void setParameterVector(ParameterVector const &vector) noexcept;
 
     double &operator[](int i) { return (i < 4) ? _linear[i] : _translation[i - 4]; }
     double operator[](int i) const { return (i < 4) ? _linear[i] : _translation[i - 4]; }
@@ -165,33 +166,33 @@ public:
     /**
      * Construct a new AffineTransform from two others: (B * A)(p) = B(A(p))
      */
-    AffineTransform operator*(AffineTransform const &other) const {
+    AffineTransform operator*(AffineTransform const &other) const noexcept {
         return AffineTransform(getLinear() * other.getLinear(),
                                getLinear()(other.getTranslation()) + getTranslation());
     }
 
-    AffineTransform &operator=(AffineTransform const &) = default;
-    AffineTransform &operator=(AffineTransform &&) = default;
+    AffineTransform &operator=(AffineTransform const &) noexcept = default;
+    AffineTransform &operator=(AffineTransform &&) noexcept = default;
 
-    AffineTransform &operator+=(AffineTransform const &other) {
+    AffineTransform &operator+=(AffineTransform const &other) noexcept {
         _linear += other._linear;
         _translation += other._translation;
         return *this;
     }
 
-    AffineTransform operator+(AffineTransform const &other) {
+    AffineTransform operator+(AffineTransform const &other) noexcept {
         AffineTransform tmp(*this);
         tmp += other;
         return tmp;
     }
 
-    AffineTransform &operator-=(AffineTransform const &other) {
+    AffineTransform &operator-=(AffineTransform const &other) noexcept {
         _linear -= other._linear;
         _translation -= other._translation;
         return *this;
     }
 
-    AffineTransform operator-(AffineTransform const &other) {
+    AffineTransform operator-(AffineTransform const &other) noexcept {
         AffineTransform tmp(*this);
         tmp -= other;
         return tmp;
@@ -209,7 +210,9 @@ public:
      *     \end{array}\right]
      *  @f$
      */
-    static AffineTransform makeScaling(double s) { return AffineTransform(LinearTransform::makeScaling(s)); }
+    static AffineTransform makeScaling(double s) noexcept {
+        return AffineTransform(LinearTransform::makeScaling(s));
+    }
 
     /**
      *  Construct a new AffineTransform that represents a non-uniform
@@ -224,7 +227,7 @@ public:
      *     \end{array}\right]
      *  @f$
      */
-    static AffineTransform makeScaling(double s, double t) {
+    static AffineTransform makeScaling(double s, double t) noexcept {
         return AffineTransform(LinearTransform::makeScaling(s, t));
     }
     /**
@@ -239,7 +242,9 @@ public:
      *     \end{array}\right]
      *  @f$
      */
-    static AffineTransform makeRotation(Angle t) { return AffineTransform(LinearTransform::makeRotation(t)); }
+    static AffineTransform makeRotation(Angle t) noexcept {
+        return AffineTransform(LinearTransform::makeRotation(t));
+    }
 
     /**
      *  Construct a new AffineTransform that represents a pure translation.
@@ -253,16 +258,18 @@ public:
      *     \end{array}\right]
      *  @f$
      */
-    static AffineTransform makeTranslation(Extent2D translation) { return AffineTransform(translation); }
+    static AffineTransform makeTranslation(Extent2D translation) noexcept {
+        return AffineTransform(translation);
+    }
 
     /**
      * Take the derivative of (*this)(input) w.r.t the transform elements
      */
-    TransformDerivativeMatrix dTransform(Point2D const &input) const;
+    TransformDerivativeMatrix dTransform(Point2D const &input) const noexcept;
     /**
      * Take the derivative of (*this)(input) w.r.t the transform elements
      */
-    TransformDerivativeMatrix dTransform(Extent2D const &input) const;
+    TransformDerivativeMatrix dTransform(Extent2D const &input) const noexcept;
 
 private:
     LinearTransform _linear;

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -121,6 +121,7 @@ public:
      *          shall be within half a pixel of `center` in either dimension.
      *
      * @throws lsst::pex::exceptions::OverflowError Thrown if the resulting box would overflow.
+     * @throws lsst::pex::exceptions::InvalidParameterError Thrown if `center` is not finite.
      */
     static Box2I makeCenteredBox(Point2D const& center, Extent const& size);
 
@@ -354,8 +355,10 @@ public:
      *
      * @returns if `size` is positive, a box with size `size`; otherwise,
      *          an empty box. If the returned box is not empty, it shall be
-     *          centered on `center`.
+     *          centered on `center`. Behavior is undefined if either `center`
+     *          or `size` is non-finite.
      */
+    // It's hard to guarantee postconditions (especially size) with non-finite inputs
     static Box2D makeCenteredBox(Point2D const& center, Extent const& size) noexcept;
 
     void swap(Box2D& other) noexcept {

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -60,7 +60,7 @@ public:
     enum EdgeHandlingEnum { EXPAND, SHRINK };
 
     /// Construct an empty box.
-    Box2I() : _minimum(0), _dimensions(0) {}
+    Box2I() noexcept : _minimum(0), _dimensions(0) {}
 
     /**
      *  Construct a box from its minimum and maximum points.
@@ -81,6 +81,8 @@ public:
      *  @param[in] dimensions Box dimensions.  If either dimension coordinate is 0, the box will be empty.
      *  @param[in] invert     If true (default), invert any negative dimensions instead of creating
      *                        an empty box.
+     *
+     * @throws lsst::pex::exceptions::OverflowError Thrown if the maximum Point2I would overflow.
      */
     Box2I(Point2I const& corner, Extent2I const& dimensions, bool invert = true);
 
@@ -98,13 +100,15 @@ public:
      *                            overlap the floating-point box.  If SHRINK, the integer
      *                            box will contain only pixels completely contained by
      *                            the floating-point box.
+     *
+     * @throws lsst::pex::exceptions::InvalidParameterError Thrown if `other` is not finite.
      */
     explicit Box2I(Box2D const& other, EdgeHandlingEnum edgeHandling = EXPAND);
 
     /// Standard copy constructor.
-    Box2I(Box2I const&) = default;
-    Box2I(Box2I&&) = default;
-    ~Box2I() = default;
+    Box2I(Box2I const&) noexcept = default;
+    Box2I(Box2I&&) noexcept = default;
+    ~Box2I() noexcept = default;
 
     /**
      * Create a box centered as closely as possible on a particular point.
@@ -115,17 +119,19 @@ public:
      * @returns if `size` is positive, a box with size `size`; otherwise,
      *          an empty box. If the returned box is not empty, its center
      *          shall be within half a pixel of `center` in either dimension.
+     *
+     * @throws lsst::pex::exceptions::OverflowError Thrown if the resulting box would overflow.
      */
     static Box2I makeCenteredBox(Point2D const& center, Extent const& size);
 
-    void swap(Box2I& other) {
+    void swap(Box2I& other) noexcept {
         _minimum.swap(other._minimum);
         _dimensions.swap(other._dimensions);
     }
 
     /// Standard assignment operator.
-    Box2I& operator=(Box2I const&) = default;
-    Box2I& operator=(Box2I&&) = default;
+    Box2I& operator=(Box2I const&) noexcept = default;
+    Box2I& operator=(Box2I&&) noexcept = default;
 
     /**
      *  @name Min/Max Accessors
@@ -133,13 +139,13 @@ public:
      *  Return the minimum and maximum coordinates of the box (inclusive).
      */
     //@{
-    Point2I const getMin() const { return _minimum; }
-    int getMinX() const { return _minimum.getX(); }
-    int getMinY() const { return _minimum.getY(); }
+    Point2I const getMin() const noexcept { return _minimum; }
+    int getMinX() const noexcept { return _minimum.getX(); }
+    int getMinY() const noexcept { return _minimum.getY(); }
 
-    Point2I const getMax() const { return _minimum + _dimensions - Extent2I(1); }
-    int getMaxX() const { return _minimum.getX() + _dimensions.getX() - 1; }
-    int getMaxY() const { return _minimum.getY() + _dimensions.getY() - 1; }
+    Point2I const getMax() const noexcept { return _minimum + _dimensions - Extent2I(1); }
+    int getMaxX() const noexcept { return _minimum.getX() + _dimensions.getX() - 1; }
+    int getMaxY() const noexcept { return _minimum.getY() + _dimensions.getY() - 1; }
     //@}
 
     /**
@@ -148,13 +154,13 @@ public:
      *  Return STL-style begin (inclusive) and end (exclusive) coordinates for the box.
      */
     //@{
-    Point2I const getBegin() const { return _minimum; }
-    int getBeginX() const { return _minimum.getX(); }
-    int getBeginY() const { return _minimum.getY(); }
+    Point2I const getBegin() const noexcept { return _minimum; }
+    int getBeginX() const noexcept { return _minimum.getX(); }
+    int getBeginY() const noexcept { return _minimum.getY(); }
 
-    Point2I const getEnd() const { return _minimum + _dimensions; }
-    int getEndX() const { return _minimum.getX() + _dimensions.getX(); }
-    int getEndY() const { return _minimum.getY() + _dimensions.getY(); }
+    Point2I const getEnd() const noexcept { return _minimum + _dimensions; }
+    int getEndX() const noexcept { return _minimum.getX() + _dimensions.getX(); }
+    int getEndY() const noexcept { return _minimum.getY() + _dimensions.getY(); }
     //@}
 
     /**
@@ -163,9 +169,9 @@ public:
      *  Return the size of the box in pixels.
      */
     //@{
-    Extent2I const getDimensions() const { return _dimensions; }
-    int getWidth() const { return _dimensions.getX(); }
-    int getHeight() const { return _dimensions.getY(); }
+    Extent2I const getDimensions() const noexcept { return _dimensions; }
+    int getWidth() const noexcept { return _dimensions.getX(); }
+    int getHeight() const noexcept { return _dimensions.getY(); }
     int getArea() const { return getWidth() * getHeight(); }
     //@}
 
@@ -173,24 +179,24 @@ public:
     ndarray::View<boost::fusion::vector2<ndarray::index::Range, ndarray::index::Range> > getSlices() const;
 
     /// Return true if the box contains no points.
-    bool isEmpty() const { return _dimensions.getX() == 0 && _dimensions.getY() == 0; }
+    bool isEmpty() const noexcept { return _dimensions.getX() == 0 && _dimensions.getY() == 0; }
 
     /// Return true if the box contains the point.
-    bool contains(Point2I const& point) const;
+    bool contains(Point2I const& point) const noexcept;
 
     /**
      *  Return true if all points contained by other are also contained by this.
      *
      *  An empty box is contained by every other box, including other empty boxes.
      */
-    bool contains(Box2I const& other) const;
+    bool contains(Box2I const& other) const noexcept;
 
     /**
      *  Return true if any points in other are also in this.
      *
      *  Any overlap operation involving an empty box returns false.
      */
-    bool overlaps(Box2I const& other) const;
+    bool overlaps(Box2I const& other) const noexcept;
 
     /**
      *  Increase the size of the box by the given buffer amount in all directions.
@@ -223,22 +229,27 @@ public:
     /// Expand this to ensure that this->contains(other).
     void include(Box2I const& other);
 
-    /// Shrink this to ensure that other.contains(*this).
-    void clip(Box2I const& other);
+    /** Shrink this to ensure that `other.contains(*this)`.
+     *
+     * In particular, if `other` and this box do not overlap this box will become empty.
+     *
+     * @param other the box that must contain this one
+     */
+    void clip(Box2I const& other) noexcept;
 
     /**
      *  Compare two boxes for equality.
      *
      *  All empty boxes are equal.
      */
-    bool operator==(Box2I const& other) const;
+    bool operator==(Box2I const& other) const noexcept;
 
     /**
      *  Compare two boxes for equality.
      *
      *  All empty boxes are equal.
      */
-    bool operator!=(Box2I const& other) const;
+    bool operator!=(Box2I const& other) const noexcept;
 
     /**
      * Get the corner points
@@ -292,7 +303,7 @@ public:
     static double const INVALID;
 
     /// Construct an empty box.
-    Box2D();
+    Box2D() noexcept;
 
     /**
      *  Construct a box from its minimum and maximum points.
@@ -304,7 +315,7 @@ public:
      *  @param[in] invert    If true (default), swap the minimum and maximum coordinates if
      *                       minimum > maximum instead of creating an empty box.
      */
-    Box2D(Point2D const& minimum, Point2D const& maximum, bool invert = true);
+    Box2D(Point2D const& minimum, Point2D const& maximum, bool invert = true) noexcept;
 
     /**
      *  Construct a box from one corner and dimensions.
@@ -316,7 +327,7 @@ public:
      *  @param[in] invert     If true (default), invert any negative dimensions instead of creating
      *                        an empty box.
      */
-    Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert = true);
+    Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert = true) noexcept;
 
     /**
      *  Construct a floating-point box from an integer box.
@@ -327,13 +338,13 @@ public:
      *  the same dimensions as the input integer box, its minimum/maximum coordinates
      *  are 0.5 smaller/greater.
      */
-    explicit Box2D(Box2I const& other);
+    explicit Box2D(Box2I const& other) noexcept;
 
     /// Standard copy constructor.
-    Box2D(Box2D const&) = default;
-    Box2D(Box2D&&) = default;
+    Box2D(Box2D const&) noexcept = default;
+    Box2D(Box2D&&) noexcept = default;
 
-    ~Box2D() = default;
+    ~Box2D() noexcept = default;
 
     /**
      * Create a box centered on a particular point.
@@ -345,16 +356,16 @@ public:
      *          an empty box. If the returned box is not empty, it shall be
      *          centered on `center`.
      */
-    static Box2D makeCenteredBox(Point2D const& center, Extent const& size);
+    static Box2D makeCenteredBox(Point2D const& center, Extent const& size) noexcept;
 
-    void swap(Box2D& other) {
+    void swap(Box2D& other) noexcept {
         _minimum.swap(other._minimum);
         _maximum.swap(other._maximum);
     }
 
     /// Standard assignment operator.
-    Box2D& operator=(Box2D const&) = default;
-    Box2D& operator=(Box2D&&) = default;
+    Box2D& operator=(Box2D const&) noexcept = default;
+    Box2D& operator=(Box2D&&) noexcept = default;
 
     /**
      *  @name Min/Max Accessors
@@ -362,13 +373,13 @@ public:
      *  Return the minimum (inclusive) and maximum (exclusive) coordinates of the box.
      */
     //@{
-    Point2D const getMin() const { return _minimum; }
-    double getMinX() const { return _minimum.getX(); }
-    double getMinY() const { return _minimum.getY(); }
+    Point2D const getMin() const noexcept { return _minimum; }
+    double getMinX() const noexcept { return _minimum.getX(); }
+    double getMinY() const noexcept { return _minimum.getY(); }
 
-    Point2D const getMax() const { return _maximum; }
-    double getMaxX() const { return _maximum.getX(); }
-    double getMaxY() const { return _maximum.getY(); }
+    Point2D const getMax() const noexcept { return _maximum; }
+    double getMaxX() const noexcept { return _maximum.getX(); }
+    double getMaxY() const noexcept { return _maximum.getY(); }
     //@}
 
     /**
@@ -377,10 +388,10 @@ public:
      *  Return the size of the box.
      */
     //@{
-    Extent2D const getDimensions() const { return isEmpty() ? Extent2D(0.0) : _maximum - _minimum; }
-    double getWidth() const { return isEmpty() ? 0 : _maximum.getX() - _minimum.getX(); }
-    double getHeight() const { return isEmpty() ? 0 : _maximum.getY() - _minimum.getY(); }
-    double getArea() const {
+    Extent2D const getDimensions() const noexcept { return isEmpty() ? Extent2D(0.0) : _maximum - _minimum; }
+    double getWidth() const noexcept { return isEmpty() ? 0 : _maximum.getX() - _minimum.getX(); }
+    double getHeight() const noexcept { return isEmpty() ? 0 : _maximum.getY() - _minimum.getY(); }
+    double getArea() const noexcept {
         Extent2D dim(getDimensions());
         return dim.getX() * dim.getY();
     }
@@ -392,30 +403,32 @@ public:
      *  Return the center coordinate of the box.
      */
     //@{
-    Point2D const getCenter() const { return Point2D((_minimum.asEigen() + _maximum.asEigen()) * 0.5); }
-    double getCenterX() const { return (_minimum.getX() + _maximum.getX()) * 0.5; }
-    double getCenterY() const { return (_minimum.getY() + _maximum.getY()) * 0.5; }
+    Point2D const getCenter() const noexcept {
+        return Point2D((_minimum.asEigen() + _maximum.asEigen()) * 0.5);
+    }
+    double getCenterX() const noexcept { return (_minimum.getX() + _maximum.getX()) * 0.5; }
+    double getCenterY() const noexcept { return (_minimum.getY() + _maximum.getY()) * 0.5; }
     //@}
 
     /// Return true if the box contains no points.
-    bool isEmpty() const { return _minimum.getX() != _minimum.getX(); }
+    bool isEmpty() const noexcept { return _minimum.getX() != _minimum.getX(); }
 
     /// Return true if the box contains the point.
-    bool contains(Point2D const& point) const;
+    bool contains(Point2D const& point) const noexcept;
 
     /**
      *  Return true if all points contained by other are also contained by this.
      *
      *  An empty box is contained by every other box, including other empty boxes.
      */
-    bool contains(Box2D const& other) const;
+    bool contains(Box2D const& other) const noexcept;
 
     /**
      *  Return true if any points in other are also in this.
      *
      *  Any overlap operation involving an empty box returns false.
      */
-    bool overlaps(Box2D const& other) const;
+    bool overlaps(Box2D const& other) const noexcept;
 
     /**
      *  Increase the size of the box by the given buffer amount in all directions.
@@ -449,27 +462,32 @@ public:
      *  be adjusted to ensure the point is actually contained
      *  by the box instead of sitting on its exclusive upper edge.
      */
-    void include(Point2D const& point);
+    void include(Point2D const& point) noexcept;
 
     /// Expand this to ensure that this->contains(other).
-    void include(Box2D const& other);
+    void include(Box2D const& other) noexcept;
 
-    /// Shrink this to ensure that other.contains(*this).
-    void clip(Box2D const& other);
+    /** Shrink this to ensure that `other.contains(*this)`.
+     *
+     * In particular, if `other` and this box do not overlap this box will become empty.
+     *
+     * @param other the box that must contain this one
+     */
+    void clip(Box2D const& other) noexcept;
 
     /**
      *  Compare two boxes for equality.
      *
      *  All empty boxes are equal.
      */
-    bool operator==(Box2D const& other) const;
+    bool operator==(Box2D const& other) const noexcept;
 
     /**
      *  Compare two boxes for equality.
      *
      *  All empty boxes are equal.
      */
-    bool operator!=(Box2D const& other) const;
+    bool operator!=(Box2D const& other) const noexcept;
 
     /**
      * Get the corner points
@@ -484,7 +502,7 @@ public:
     }
 
 private:
-    void _tweakMax(int n) {
+    void _tweakMax(int n) noexcept {
         if (_maximum[n] < 0.0) {
             _maximum[n] *= (1.0 - EPSILON);
         } else if (_maximum[n] > 0.0) {

--- a/include/lsst/geom/CoordinateBase.h
+++ b/include/lsst/geom/CoordinateBase.h
@@ -26,6 +26,7 @@
 #define LSST_GEOM_COORDINATEBASE_H
 
 #include <iostream>
+#include <type_traits>
 #include <tuple>
 #include <utility>
 
@@ -39,6 +40,11 @@ class Point;
 template <typename T, int N = 2>
 class Extent;
 
+/// Test that a type is nothrow-copy-convertible from U to T.
+template <typename T, typename U>
+bool constexpr IS_NOTHROW_CONVERTIBLE =
+        std::is_nothrow_copy_constructible<T>::value&& noexcept(static_cast<T>(std::declval<U>()));
+
 /**
  *  A CRTP base class for coordinate objects.
  *
@@ -51,12 +57,23 @@ public:
     typedef T Element;
     static int const dimensions = N;
     typedef Eigen::Matrix<T, N, 1, Eigen::DontAlign> EigenVector;
+    static bool constexpr IS_ELEMENT_NOTHROW_COPYABLE = std::is_nothrow_copy_constructible<T>::value;
+    static bool constexpr IS_ELEMENT_NOTHROW_ASSIGNABLE = std::is_nothrow_copy_assignable<T>::value;
 
-    CoordinateBase(CoordinateBase const&) = default;
-    CoordinateBase(CoordinateBase&&) = default;
-    CoordinateBase& operator=(CoordinateBase const&) = default;
-    CoordinateBase& operator=(CoordinateBase&&) = default;
-    ~CoordinateBase() = default;
+    // Can't use both =default and noexcept until Eigen supports noexcept
+    CoordinateBase(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(other._vector) {}
+    CoordinateBase(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(std::move(other._vector)) {}
+    CoordinateBase& operator=(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = other._vector;
+        return *this;
+    }
+    CoordinateBase& operator=(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = std::move(other._vector);
+        return *this;
+    }
+    ~CoordinateBase() noexcept = default;
 
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }
@@ -69,7 +86,7 @@ public:
      *  The fact that this returns by const reference rather than by value should not be considered
      *  part of the API; this is merely an optimization enabled by the implementation.
      */
-    EigenVector const& asEigen() const { return _vector; }
+    EigenVector const& asEigen() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { return _vector; }
 
 protected:
     /**
@@ -77,7 +94,8 @@ protected:
      *
      *  A public constructor with the same signature is expected for subclasses.
      */
-    explicit CoordinateBase(T val = static_cast<T>(0)) : _vector(EigenVector::Constant(val)) {}
+    explicit CoordinateBase(T val = static_cast<T>(0)) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(EigenVector::Constant(val)) {}
 
     /**
      *  Initialize all elements from an N-d Eigen vector.
@@ -87,7 +105,7 @@ protected:
     template <typename Vector>
     explicit CoordinateBase(Eigen::MatrixBase<Vector> const& vector) : _vector(vector) {}
 
-    void _swap(CoordinateBase& other) { _vector.swap(other._vector); }
+    void _swap(CoordinateBase& other) noexcept { _vector.swap(other._vector); }
     EigenVector _vector;
 };
 
@@ -100,7 +118,9 @@ protected:
  */
 template <typename Derived, typename T, int N>
 bool allclose(CoordinateBase<Derived, T, N> const& a, CoordinateBase<Derived, T, N> const& b,
-              T rtol = static_cast<T>(1E-5), T atol = static_cast<T>(1E-8));
+              T rtol = static_cast<T>(1E-5),
+              T atol = static_cast<T>(1E-8)) noexcept(std::is_nothrow_copy_constructible<T>::value&&
+                                                              std::is_nothrow_copy_assignable<T>::value);
 
 /**
  *  Specialization of CoordinateBase for 2 dimensions.
@@ -111,12 +131,23 @@ public:
     typedef T Element;
     static int const dimensions = 2;
     typedef Eigen::Matrix<T, 2, 1, Eigen::DontAlign> EigenVector;
+    static bool constexpr IS_ELEMENT_NOTHROW_COPYABLE = std::is_nothrow_copy_constructible<T>::value;
+    static bool constexpr IS_ELEMENT_NOTHROW_ASSIGNABLE = std::is_nothrow_copy_assignable<T>::value;
 
-    CoordinateBase(CoordinateBase const&) = default;
-    CoordinateBase(CoordinateBase&&) = default;
-    CoordinateBase& operator=(CoordinateBase const&) = default;
-    CoordinateBase& operator=(CoordinateBase&&) = default;
-    ~CoordinateBase() = default;
+    // Can't use both =default and noexcept until Eigen supports noexcept
+    CoordinateBase(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(other._vector) {}
+    CoordinateBase(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(std::move(other._vector)) {}
+    CoordinateBase& operator=(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = other._vector;
+        return *this;
+    }
+    CoordinateBase& operator=(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = std::move(other._vector);
+        return *this;
+    }
+    ~CoordinateBase() noexcept = default;
 
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }
@@ -129,27 +160,32 @@ public:
      *  The fact that this returns by const reference rather than by value should not be considered
      *  part of the API; this is merely an optimization enabled by the implementation.
      */
-    EigenVector const& asEigen() const { return _vector; }
+    EigenVector const& asEigen() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { return _vector; }
 
-    T const& getX() const { return _vector.x(); }
-    T const& getY() const { return _vector.y(); }
-    T& getX() { return _vector.x(); }
-    T& getY() { return _vector.y(); }
-    void setX(T x) { _vector.x() = x; }
-    void setY(T y) { _vector.y() = y; }
+    T const& getX() const noexcept { return _vector.x(); }
+    T const& getY() const noexcept { return _vector.y(); }
+    T& getX() noexcept { return _vector.x(); }
+    T& getY() noexcept { return _vector.y(); }
+    void setX(T x) noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { _vector.x() = x; }
+    void setY(T y) noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { _vector.y() = y; }
 
     /// Return a std::pair representation of the coordinate object.
-    std::pair<T, T> asPair() const { return std::make_pair(_vector.x(), _vector.y()); }
+    std::pair<T, T> asPair() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) {
+        return std::make_pair(_vector.x(), _vector.y());
+    }
 
     /// Return a std::tuple representation of the coordinate object.
-    std::tuple<T, T> asTuple() const { return std::make_tuple(_vector.x(), _vector.y()); }
+    std::tuple<T, T> asTuple() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) {
+        return std::make_tuple(_vector.x(), _vector.y());
+    }
 
 protected:
-    explicit CoordinateBase(T val = static_cast<T>(0)) : _vector(EigenVector::Constant(val)) {}
+    explicit CoordinateBase(T val = static_cast<T>(0)) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(EigenVector::Constant(val)) {}
 
     template <typename Vector>
     explicit CoordinateBase(Eigen::MatrixBase<Vector> const& vector) : _vector(vector) {}
-    void _swap(CoordinateBase& other) { _vector.swap(other._vector); }
+    void _swap(CoordinateBase& other) noexcept { _vector.swap(other._vector); }
     EigenVector _vector;
 };
 
@@ -162,12 +198,23 @@ public:
     typedef T Element;
     static int const dimensions = 3;
     typedef Eigen::Matrix<T, 3, 1, Eigen::DontAlign> EigenVector;
+    static bool constexpr IS_ELEMENT_NOTHROW_COPYABLE = std::is_nothrow_copy_constructible<T>::value;
+    static bool constexpr IS_ELEMENT_NOTHROW_ASSIGNABLE = std::is_nothrow_copy_assignable<T>::value;
 
-    CoordinateBase(CoordinateBase const&) = default;
-    CoordinateBase(CoordinateBase&&) = default;
-    CoordinateBase& operator=(CoordinateBase const&) = default;
-    CoordinateBase& operator=(CoordinateBase&&) = default;
-    ~CoordinateBase() = default;
+    // Can't use both =default and noexcept until Eigen supports noexcept
+    CoordinateBase(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(other._vector) {}
+    CoordinateBase(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(std::move(other._vector)) {}
+    CoordinateBase& operator=(CoordinateBase const& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = other._vector;
+        return *this;
+    }
+    CoordinateBase& operator=(CoordinateBase&& other) noexcept(IS_ELEMENT_NOTHROW_ASSIGNABLE) {
+        _vector = std::move(other._vector);
+        return *this;
+    }
+    ~CoordinateBase() noexcept = default;
 
     T& operator[](int n) { return _vector[n]; }
     T const& operator[](int n) const { return const_cast<EigenVector&>(_vector)[n]; }
@@ -180,27 +227,30 @@ public:
      *  The fact that this returns by const reference rather than by value should not be considered
      *  part of the API; this is merely an optimization enabled by the implementation.
      */
-    EigenVector const& asEigen() const { return _vector; }
+    EigenVector const& asEigen() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { return _vector; }
 
-    T const& getX() const { return _vector.x(); }
-    T const& getY() const { return _vector.y(); }
-    T const& getZ() const { return _vector.z(); }
-    T& getX() { return _vector.x(); }
-    T& getY() { return _vector.y(); }
-    T& getZ() { return _vector.z(); }
-    void setX(T x) { _vector.x() = x; }
-    void setY(T y) { _vector.y() = y; }
-    void setZ(T z) { _vector.z() = z; }
+    T const& getX() const noexcept { return _vector.x(); }
+    T const& getY() const noexcept { return _vector.y(); }
+    T const& getZ() const noexcept { return _vector.z(); }
+    T& getX() noexcept { return _vector.x(); }
+    T& getY() noexcept { return _vector.y(); }
+    T& getZ() noexcept { return _vector.z(); }
+    void setX(T x) noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { _vector.x() = x; }
+    void setY(T y) noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { _vector.y() = y; }
+    void setZ(T z) noexcept(IS_ELEMENT_NOTHROW_COPYABLE) { _vector.z() = z; }
 
     /// Return a std::tuple representation of the coordinate object.
-    std::tuple<T, T, T> asTuple() const { return std::make_tuple(_vector.x(), _vector.y(), _vector.z()); }
+    std::tuple<T, T, T> asTuple() const noexcept(IS_ELEMENT_NOTHROW_COPYABLE) {
+        return std::make_tuple(_vector.x(), _vector.y(), _vector.z());
+    }
 
 protected:
-    explicit CoordinateBase(T val = static_cast<T>(0)) : _vector(EigenVector::Constant(val)) {}
+    explicit CoordinateBase(T val = static_cast<T>(0)) noexcept(IS_ELEMENT_NOTHROW_COPYABLE)
+            : _vector(EigenVector::Constant(val)) {}
 
     template <typename Vector>
     explicit CoordinateBase(Eigen::MatrixBase<Vector> const& vector) : _vector(vector) {}
-    void _swap(CoordinateBase& other) { _vector.swap(other._vector); }
+    void _swap(CoordinateBase& other) noexcept { _vector.swap(other._vector); }
     EigenVector _vector;
 };
 

--- a/include/lsst/geom/CoordinateBase.h
+++ b/include/lsst/geom/CoordinateBase.h
@@ -47,6 +47,7 @@ class Extent;
 template <typename Derived, typename T, int N>
 class CoordinateBase {
 public:
+    static_assert(N > 0, "CoordinateBase must have a positive length.");
     typedef T Element;
     static int const dimensions = N;
     typedef Eigen::Matrix<T, N, 1, Eigen::DontAlign> EigenVector;

--- a/include/lsst/geom/CoordinateExpr.h
+++ b/include/lsst/geom/CoordinateExpr.h
@@ -52,17 +52,17 @@ class CoordinateExpr : public CoordinateBase<CoordinateExpr<N>, bool, N> {
 
 public:
     /// Construct a CoordinateExpr with all elements set to the same scalar value.
-    explicit CoordinateExpr(bool val = false) : Super(val) {}
+    explicit CoordinateExpr(bool val = false) noexcept : Super(val) {}
 
     /// Construct a CoordinateExpr from an Eigen vector.
     template <typename Vector>
     explicit CoordinateExpr(Eigen::MatrixBase<Vector> const& vector) : Super(vector) {}
 
-    CoordinateExpr(CoordinateExpr const&) = default;
-    CoordinateExpr(CoordinateExpr&&) = default;
-    CoordinateExpr& operator=(CoordinateExpr const&) = default;
-    CoordinateExpr& operator=(CoordinateExpr&&) = default;
-    ~CoordinateExpr() = default;
+    CoordinateExpr(CoordinateExpr const&) noexcept = default;
+    CoordinateExpr(CoordinateExpr&&) noexcept = default;
+    CoordinateExpr& operator=(CoordinateExpr const&) noexcept = default;
+    CoordinateExpr& operator=(CoordinateExpr&&) noexcept = default;
+    ~CoordinateExpr() noexcept = default;
 
     /**
      *  @name Logical operators
@@ -70,15 +70,15 @@ public:
      *  These operators do not provide interoperability with scalars.
      */
     //@{
-    CoordinateExpr and_(CoordinateExpr const& rhs) const;
-    CoordinateExpr or_(CoordinateExpr const& rhs) const;
-    CoordinateExpr not_() const;
+    CoordinateExpr and_(CoordinateExpr const& rhs) const noexcept;
+    CoordinateExpr or_(CoordinateExpr const& rhs) const noexcept;
+    CoordinateExpr not_() const noexcept;
     //@}
 };
 
 /// Return true if all elements are true.
 template <int N>
-inline bool all(CoordinateExpr<N> const& expr) {
+inline bool all(CoordinateExpr<N> const& expr) noexcept {
     for (int n = 0; n < N; ++n)
         if (!expr[n]) return false;
     return true;
@@ -86,7 +86,7 @@ inline bool all(CoordinateExpr<N> const& expr) {
 
 /// Return true if any elements are true.
 template <int N>
-inline bool any(CoordinateExpr<N> const& expr) {
+inline bool any(CoordinateExpr<N> const& expr) noexcept {
     for (int n = 0; n < N; ++n)
         if (expr[n]) return true;
     return false;

--- a/include/lsst/geom/Extent.h
+++ b/include/lsst/geom/Extent.h
@@ -74,14 +74,14 @@ public:
      *
      *  Returns true iff all(this->eq(other));
      */
-    bool operator==(Extent<T, N> const &other) const { return all(this->eq(other)); }
+    bool operator==(Extent<T, N> const &other) const noexcept { return all(this->eq(other)); }
 
     /**
      *  Standard inequality comparison.
      *
      *  Returns true iff any(this->ne(other));
      */
-    bool operator!=(Extent<T, N> const &other) const { return any(this->ne(other)); }
+    bool operator!=(Extent<T, N> const &other) const noexcept { return any(this->ne(other)); }
 
     /**
      *  @name Named comparison functions
@@ -96,18 +96,30 @@ public:
      *  are both ubiquitous and easy to interpret.
      */
     //@{
-    CoordinateExpr<N> eq(Extent<T, N> const &other) const;
-    CoordinateExpr<N> ne(Extent<T, N> const &other) const;
-    CoordinateExpr<N> lt(Extent<T, N> const &other) const;
-    CoordinateExpr<N> le(Extent<T, N> const &other) const;
-    CoordinateExpr<N> gt(Extent<T, N> const &other) const;
-    CoordinateExpr<N> ge(Extent<T, N> const &other) const;
-    CoordinateExpr<N> eq(T scalar) const { return this->eq(Extent<T, N>(scalar)); }
-    CoordinateExpr<N> ne(T scalar) const { return this->ne(Extent<T, N>(scalar)); }
-    CoordinateExpr<N> lt(T scalar) const { return this->lt(Extent<T, N>(scalar)); }
-    CoordinateExpr<N> le(T scalar) const { return this->le(Extent<T, N>(scalar)); }
-    CoordinateExpr<N> gt(T scalar) const { return this->gt(Extent<T, N>(scalar)); }
-    CoordinateExpr<N> ge(T scalar) const { return this->ge(Extent<T, N>(scalar)); }
+    CoordinateExpr<N> eq(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> ne(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> lt(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> le(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> gt(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> ge(Extent<T, N> const &other) const noexcept;
+    CoordinateExpr<N> eq(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->eq(Extent<T, N>(scalar));
+    }
+    CoordinateExpr<N> ne(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->ne(Extent<T, N>(scalar));
+    }
+    CoordinateExpr<N> lt(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->lt(Extent<T, N>(scalar));
+    }
+    CoordinateExpr<N> le(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->le(Extent<T, N>(scalar));
+    }
+    CoordinateExpr<N> gt(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->gt(Extent<T, N>(scalar));
+    }
+    CoordinateExpr<N> ge(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->ge(Extent<T, N>(scalar));
+    }
     //@}
 
     /**
@@ -116,23 +128,27 @@ public:
      *  No scalar interoperability is provided for Extent additive arithmetic operations.
      */
     //@{
-    Point<T, N> operator+(Point<T, N> const &other) const;
-    Extent<T, N> operator+(Extent<T, N> const &other) const {
+    Point<T, N> operator+(Point<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE);
+    Extent<T, N> operator+(Extent<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         return Extent<T, N>(this->_vector + other._vector);
     }
-    Extent<T, N> operator-(Extent<T, N> const &other) const {
+    Extent<T, N> operator-(Extent<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         return Extent<T, N>(this->_vector - other._vector);
     }
-    Extent<T, N> &operator+=(Extent<T, N> const &other) {
+    Extent<T, N> &operator+=(Extent<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector += other._vector;
         return static_cast<Extent<T, N> &>(*this);
     }
-    Extent<T, N> &operator-=(Extent<T, N> const &other) {
+    Extent<T, N> &operator-=(Extent<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector -= other._vector;
         return static_cast<Extent<T, N> &>(*this);
     }
-    Extent<T, N> operator+() const { return static_cast<Extent<T, N> const &>(*this); }
-    Extent<T, N> operator-() const { return Extent<T, N>(-this->_vector); }
+    Extent<T, N> operator+() const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return static_cast<Extent<T, N> const &>(*this);
+    }
+    Extent<T, N> operator-() const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return Extent<T, N>(-this->_vector);
+    }
     //@}
 
     /**
@@ -141,20 +157,24 @@ public:
      *  As usual with matrices and vectors, Extent can be multiplied or divided by a scalar.
      */
     //@{
-    Extent<T, N> operator*(T scalar) const { return Extent<T, N>(this->_vector * scalar); }
-    Extent<T, N> &operator*=(T scalar) {
+    Extent<T, N> operator*(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return Extent<T, N>(this->_vector * scalar);
+    }
+    Extent<T, N> &operator*=(T scalar) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector *= scalar;
         return static_cast<Extent<T, N> &>(*this);
     }
-    Extent<T, N> operator/(T scalar) const { return Extent<T, N>(this->_vector / scalar); }
-    Extent<T, N> &operator/=(T scalar) {
+    Extent<T, N> operator/(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return Extent<T, N>(this->_vector / scalar);
+    }
+    Extent<T, N> &operator/=(T scalar) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector /= scalar;
         return static_cast<Extent<T, N> &>(*this);
     }
     //@}
 
     /// Cast this object to an Extent of the same numeric type and dimensionality.
-    Point<T, N> asPoint() const;
+    Point<T, N> asPoint() const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE);
 
     std::string toString() const {
         std::stringstream out;
@@ -171,7 +191,8 @@ public:
 
 protected:
     /// Construct an Extent<T,N> with all elements set to the same scalar value.
-    explicit ExtentBase(T val = static_cast<T>(0)) : Super(val) {}
+    explicit ExtentBase(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(val) {}
 
     /// Construct an Extent from an Eigen vector.
     template <typename Vector>
@@ -193,22 +214,23 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct an Extent with all elements set to the same scalar value.
-    explicit Extent(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Extent(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     /// Construct an Extent from an Eigen vector.
-    explicit Extent(EigenVector const &vector) : Super(vector) {}
+    explicit Extent(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Point.
-    explicit Extent(Point<T, N> const &other);
+    explicit Extent(Point<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE);
 
     /// Explicit constructor from Extent of different type (if allowed)
     template <typename U>
-    explicit Extent(Extent<U, N> const &other);
+    explicit Extent(Extent<U, N> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
     template <typename U>
-    explicit Extent(Point<U, N> const &other);
+    explicit Extent(Point<U, N> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
-    Extent(Extent const &other);
-    Extent(Extent &&other);
+    // Should be consistent with converting constructors
+    Extent(Extent const &other) = default;
+    Extent(Extent &&other) = default;
     ~Extent() = default;
 
     Extent &operator=(Extent const &other) = default;
@@ -220,7 +242,7 @@ public:
     /// Return the L2 norm of the Extent (sqrt(x^2 + y^2 + ...)).
     T computeNorm() const { return this->asEigen().norm(); }
 
-    void swap(Extent &other) { this->_swap(other); }
+    void swap(Extent &other) noexcept { this->_swap(other); }
 };
 
 /**
@@ -236,40 +258,44 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct an Extent with all elements set to the same scalar value.
-    explicit Extent(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Extent(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     /// Construct an Extent from an Eigen vector.
-    explicit Extent(EigenVector const &vector) : Super(vector) {}
+    explicit Extent(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Point.
-    explicit Extent(Point<T, 2> const &other);
+    explicit Extent(Point<T, 2> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE);
 
     /// Explicit constructor from Extent of different type (if allowed)
     template <typename U>
-    explicit Extent(Extent<U, 2> const &other);
+    explicit Extent(Extent<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
     template <typename U>
-    explicit Extent(Point<U, 2> const &other);
+    explicit Extent(Point<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
     /// Construct from two scalars.
-    explicit Extent(T x, T y) : Super(EigenVector(x, y)) {}
+    explicit Extent(T x, T y) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(EigenVector(x, y)) {}
 
     /// Construct from a two-element array.
-    explicit Extent(T const xy[2]) : Super(EigenVector(xy[0], xy[1])) {}
+    explicit Extent(T const xy[2]) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xy[0], xy[1])) {}
 
     /// Construct from a std::pair.
-    explicit Extent(std::pair<T, T> const &xy) : Super(EigenVector(xy.first, xy.second)) {}
+    explicit Extent(std::pair<T, T> const &xy) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xy.first, xy.second)) {}
 
     /// Construct from std::tuple.
-    explicit Extent(std::tuple<T, T> const &xy) : Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
+    explicit Extent(std::tuple<T, T> const &xy) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
 
-    Extent(Extent const &other);
-    Extent(Extent &&other);
+    // Should be consistent with converting constructors
+    Extent(Extent const &other) = default;
+    Extent(Extent &&other) = default;
     ~Extent() = default;
 
     Extent &operator=(Extent const &other) = default;
     Extent &operator=(Extent &&other) = default;
 
-    void swap(Extent &other) { this->_swap(other); }
+    void swap(Extent &other) noexcept { this->_swap(other); }
 };
 
 /**
@@ -285,59 +311,56 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct an Extent with all elements set to the same scalar value.
-    explicit Extent(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Extent(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     /// Construct an Extent from an Eigen vector.
-    explicit Extent(EigenVector const &vector) : Super(vector) {}
+    explicit Extent(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Point.
-    explicit Extent(Point<T, 3> const &other);
+    explicit Extent(Point<T, 3> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE);
 
     /// Explicit constructor from Extent of different type (if allowed)
     template <typename U>
-    explicit Extent(Extent<U, 3> const &other);
+    explicit Extent(Extent<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
     template <typename U>
-    explicit Extent(Point<U, 3> const &other);
+    explicit Extent(Point<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
     /// Construct from three scalars.
-    explicit Extent(T x, T y, T z) : Super(EigenVector(x, y, z)) {}
+    explicit Extent(T x, T y, T z) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(x, y, z)) {}
 
-    /// Construct from a two-element array.
-    explicit Extent(T const xyz[3]) : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
+    /// Construct from a three-element array.
+    explicit Extent(T const xyz[3]) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
 
     /// Construct from std::tuple.
-    explicit Extent(std::tuple<T, T, T> const &xyz)
+    explicit Extent(std::tuple<T, T, T> const &xyz) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
             : Super(EigenVector(std::get<0>(xyz), std::get<1>(xyz), std::get<2>(xyz))) {}
 
-    Extent(Extent const &other);
-    Extent(Extent &&other);
+    // Should be consistent with converting constructors
+    Extent(Extent const &other) = default;
+    Extent(Extent &&other) = default;
     ~Extent() = default;
 
     Extent &operator=(Extent const &other) = default;
     Extent &operator=(Extent &&other) = default;
 
-    void swap(Extent &other) { this->_swap(other); }
+    void swap(Extent &other) noexcept { this->_swap(other); }
 };
 
 // Constructor for any 2D type from 2I type
 template <typename T>
 template <typename U>
-Extent<T, 2>::Extent(Extent<U, 2> const &other) {
+Extent<T, 2>::Extent(Extent<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) {
     static_assert((!std::is_same<T, U>::value && std::is_integral<U>::value),
                   "can only construct from Extent of different but integral type");
     this->setX(static_cast<T>(other.getX()));
     this->setY(static_cast<T>(other.getY()));
 };
 
-// Should be consistent with converting constructor
-template <typename T>
-Extent<T, 2>::Extent(Extent<T, 2> const &) = default;
-template <typename T>
-Extent<T, 2>::Extent(Extent<T, 2> &&) = default;
-
 template <typename T>
 template <typename U>
-Extent<T, 2>::Extent(Point<U, 2> const &other) {
+Extent<T, 2>::Extent(Point<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) {
     static_assert((!std::is_same<T, U>::value && std::is_integral<U>::value),
                   "can only construct from Extent of different but integral type");
     this->setX(static_cast<T>(other.getX()));
@@ -347,7 +370,7 @@ Extent<T, 2>::Extent(Point<U, 2> const &other) {
 // Constructor for any 3D type from 3I type
 template <typename T>
 template <typename U>
-Extent<T, 3>::Extent(Extent<U, 3> const &other) {
+Extent<T, 3>::Extent(Extent<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) {
     static_assert((!std::is_same<T, U>::value && std::is_integral<U>::value),
                   "can only construct from Extent of different but integral type");
     this->setX(static_cast<T>(other.getX()));
@@ -355,16 +378,10 @@ Extent<T, 3>::Extent(Extent<U, 3> const &other) {
     this->setZ(static_cast<T>(other.getZ()));
 };
 
-// Should be consistent with converting constructor
-template <typename T>
-Extent<T, 3>::Extent(Extent<T, 3> const &) = default;
-template <typename T>
-Extent<T, 3>::Extent(Extent<T, 3> &&) = default;
-
 // Constructor for any 3D type from 3I type
 template <typename T>
 template <typename U>
-Extent<T, 3>::Extent(Point<U, 3> const &other) {
+Extent<T, 3>::Extent(Point<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) {
     static_assert((!std::is_same<T, U>::value && std::is_integral<U>::value),
                   "can only construct from Extent of different but integral type");
     this->setX(static_cast<T>(other.getX()));
@@ -385,7 +402,7 @@ typedef Extent<double, 3> Extent3D;
  *  In Python, this is available as both a free function and a method on ExtentD.
  */
 template <int N>
-Extent<int, N> truncate(Extent<double, N> const &input);
+Extent<int, N> truncate(Extent<double, N> const &input) noexcept;
 
 /**
  *  Return the component-wise floor (round towards more negative).
@@ -393,7 +410,7 @@ Extent<int, N> truncate(Extent<double, N> const &input);
  *  In Python, this is available as both a free function and a method on ExtentD.
  */
 template <int N>
-Extent<int, N> floor(Extent<double, N> const &input);
+Extent<int, N> floor(Extent<double, N> const &input) noexcept;
 
 /**
  *  Return the component-wise ceil (round towards more positive).
@@ -401,71 +418,72 @@ Extent<int, N> floor(Extent<double, N> const &input);
  *  In Python, this is available as both a free function and a method on ExtentD.
  */
 template <int N>
-Extent<int, N> ceil(Extent<double, N> const &input);
+Extent<int, N> ceil(Extent<double, N> const &input) noexcept;
 
 // Some operators below need to take ExtentBase arguments rather than Extent to
 // avoid ambiguous overloads (since some competing operators are defined as member
 // functions on ExtentBase).
 
 template <typename T, int N>
-Extent<T, N> operator*(T scalar, ExtentBase<T, N> const &rhs) {
+Extent<T, N> operator*(T scalar,
+                       ExtentBase<T, N> const &rhs) noexcept(ExtentBase<T, N>::IS_ELEMENT_NOTHROW_COPYABLE) {
     return rhs * scalar;
 }
 
 template <int N>
-Extent<double, N> operator*(ExtentBase<int, N> const &lhs, double rhs) {
+Extent<double, N> operator*(ExtentBase<int, N> const &lhs, double rhs) noexcept {
     return Extent<double, N>(static_cast<Extent<int, N> const &>(lhs)) * rhs;
 }
 
 template <int N>
-void operator*=(ExtentBase<int, N> &lhs, double rhs) {
+void operator*=(ExtentBase<int, N> &lhs, double rhs) noexcept {
     // use "N < 0" so assertion is dependent on template instantiation, instead of triggering all the time
     static_assert(N < 0, "In-place multiplication of Extent<int,N> by double would truncate.");
 }
 
 template <int N>
-Extent<double, N> operator/(ExtentBase<int, N> const &lhs, double rhs) {
+Extent<double, N> operator/(ExtentBase<int, N> const &lhs, double rhs) noexcept {
     return Extent<double, N>(static_cast<Extent<int, N> const &>(lhs)) / rhs;
 }
 
 template <int N>
-void operator/=(ExtentBase<int, N> &lhs, double rhs) {
+void operator/=(ExtentBase<int, N> &lhs, double rhs) noexcept {
     // use "N < 0" so assertion is dependent on template instantiation, instead of triggering all the time
     static_assert(N < 0, "In-place division of Extent<int,N> by double would truncate.");
 }
 
 template <int N>
-Extent<double, N> operator*(double lhs, ExtentBase<int, N> const &rhs) {
+Extent<double, N> operator*(double lhs, ExtentBase<int, N> const &rhs) noexcept {
     return lhs * Extent<double, N>(static_cast<Extent<int, N> const &>(rhs));
 }
 
 template <int N>
-Extent<double, N> operator+(Extent<double, N> const &lhs, Extent<int, N> const &rhs) {
+Extent<double, N> operator+(Extent<double, N> const &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs + Extent<double, N>(rhs);
 }
 
 template <int N>
-Extent<double, N> &operator+=(Extent<double, N> &lhs, Extent<int, N> const &rhs) {
+Extent<double, N> &operator+=(Extent<double, N> &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs += Extent<double, N>(rhs);
 }
 
 template <int N>
-Extent<double, N> operator-(Extent<double, N> const &lhs, Extent<int, N> const &rhs) {
+Extent<double, N> operator-(Extent<double, N> const &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs - Extent<double, N>(rhs);
 }
 
 template <int N>
-Extent<double, N> &operator-=(Extent<double, N> &lhs, Extent<int, N> const &rhs) {
+Extent<double, N> &operator-=(Extent<double, N> &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs -= Extent<double, N>(rhs);
 }
 
 template <int N>
-Extent<double, N> operator+(Extent<int, N> const &lhs, Extent<double, N> const &rhs) {
+Extent<double, N> operator+(Extent<int, N> const &lhs, Extent<double, N> const &rhs) noexcept {
     return Extent<double, N>(lhs) + rhs;
 }
 
 template <int N>
-Extent<double, N> operator-(Extent<int, N> const &lhs, Extent<double, N> const &rhs) {
+Extent<double, N> operator-(Extent<int, N> const &lhs, Extent<double, N> const &rhs) noexcept {
     return Extent<double, N>(lhs) - rhs;
 }
 

--- a/include/lsst/geom/LinearTransform.h
+++ b/include/lsst/geom/LinearTransform.h
@@ -164,7 +164,7 @@ public:
     /**
      * Return the determinant of the 2x2 matrix
      */
-    double computeDeterminant() const;
+    double computeDeterminant() const noexcept;
 
     /** Whether the transform is a no-op. */
     bool isIdentity() const noexcept { return getMatrix().isIdentity(); }

--- a/include/lsst/geom/Point.h
+++ b/include/lsst/geom/Point.h
@@ -50,14 +50,14 @@ public:
      *
      *  Returns true iff all(this->eq(other));
      */
-    bool operator==(Point<T, N> const &other) const { return all(this->eq(other)); }
+    bool operator==(Point<T, N> const &other) const noexcept { return all(this->eq(other)); }
 
     /**
      *  Standard inequality comparison.
      *
      *  Returns true iff any(this->ne(other));
      */
-    bool operator!=(Point<T, N> const &other) const { return any(this->ne(other)); }
+    bool operator!=(Point<T, N> const &other) const noexcept { return any(this->ne(other)); }
 
     /**
      *  @name Named vectorized comparison functions
@@ -72,18 +72,30 @@ public:
      *  are both ubiquitous and easy to interpret.
      */
     //@{
-    CoordinateExpr<N> eq(Point<T, N> const &other) const;
-    CoordinateExpr<N> ne(Point<T, N> const &other) const;
-    CoordinateExpr<N> lt(Point<T, N> const &other) const;
-    CoordinateExpr<N> le(Point<T, N> const &other) const;
-    CoordinateExpr<N> gt(Point<T, N> const &other) const;
-    CoordinateExpr<N> ge(Point<T, N> const &other) const;
-    CoordinateExpr<N> eq(T scalar) const { return this->eq(Point<T, N>(scalar)); }
-    CoordinateExpr<N> ne(T scalar) const { return this->ne(Point<T, N>(scalar)); }
-    CoordinateExpr<N> lt(T scalar) const { return this->lt(Point<T, N>(scalar)); }
-    CoordinateExpr<N> le(T scalar) const { return this->le(Point<T, N>(scalar)); }
-    CoordinateExpr<N> gt(T scalar) const { return this->gt(Point<T, N>(scalar)); }
-    CoordinateExpr<N> ge(T scalar) const { return this->ge(Point<T, N>(scalar)); }
+    CoordinateExpr<N> eq(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> ne(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> lt(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> le(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> gt(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> ge(Point<T, N> const &other) const noexcept;
+    CoordinateExpr<N> eq(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->eq(Point<T, N>(scalar));
+    }
+    CoordinateExpr<N> ne(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->ne(Point<T, N>(scalar));
+    }
+    CoordinateExpr<N> lt(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->lt(Point<T, N>(scalar));
+    }
+    CoordinateExpr<N> le(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->le(Point<T, N>(scalar));
+    }
+    CoordinateExpr<N> gt(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->gt(Point<T, N>(scalar));
+    }
+    CoordinateExpr<N> ge(T scalar) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return this->ge(Point<T, N>(scalar));
+    }
     //@}
 
     /**
@@ -92,34 +104,38 @@ public:
      *  No scalar interoperability is provided for Point arithmetic operations.
      */
     //@{
-    Extent<T, N> operator-(Point<T, N> const &other) const {
+    Extent<T, N> operator-(Point<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         return Extent<T, N>(this->_vector - other._vector);
     }
-    Point<T, N> operator+(Extent<T, N> const &other) const {
+    Point<T, N> operator+(Extent<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         return Point<T, N>(this->_vector + other.asEigen());
     }
-    Point<T, N> operator-(Extent<T, N> const &other) const {
+    Point<T, N> operator-(Extent<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         return Point<T, N>(this->_vector - other.asEigen());
     }
-    Point<T, N> &operator+=(Extent<T, N> const &other) {
+    Point<T, N> &operator+=(Extent<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector += other.asEigen();
         return static_cast<Point<T, N> &>(*this);
     }
-    Point<T, N> &operator-=(Extent<T, N> const &other) {
+    Point<T, N> &operator-=(Extent<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_ASSIGNABLE) {
         this->_vector -= other.asEigen();
         return static_cast<Point<T, N> &>(*this);
     }
     //@}
 
     /// Cast this object to an Extent of the same numeric type and dimensionality.
-    Extent<T, N> asExtent() const { return Extent<T, N>(static_cast<Point<T, N> const &>(*this)); }
+    Extent<T, N> asExtent() const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        return Extent<T, N>(static_cast<Point<T, N> const &>(*this));
+    }
 
     /// Shift the point by the given offset.
-    void shift(Extent<T, N> const &offset) { this->_vector += offset.asEigen(); }
+    void shift(Extent<T, N> const &offset) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
+        this->_vector += offset.asEigen();
+    }
 
-    void scale(double factor) { this->_vector *= factor; }
+    void scale(double factor) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) { this->_vector *= factor; }
 
-    double distanceSquared(PointBase<T, N> const &other) const {
+    double distanceSquared(PointBase<T, N> const &other) const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
         // the cast to double is lame but Eigen seems to require they be the same type
         return (this->asEigen() - other.asEigen()).squaredNorm();
     }
@@ -138,7 +154,7 @@ public:
     }
 
 protected:
-    explicit PointBase(T val = static_cast<T>(0)) : Super(val) {}
+    explicit PointBase(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     template <typename Vector>
     explicit PointBase(Eigen::MatrixBase<Vector> const &vector) : Super(vector) {}
@@ -157,7 +173,7 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct a Point with all elements set to the same scalar value.
-    explicit Point(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Point(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     Point(Point const &) = default;
     Point(Point &&) = default;
@@ -174,15 +190,16 @@ public:
      *  it lies on (assuming the floating point origin is the center of the first pixel).
      */
     template <typename U>
-    explicit Point(Point<U, N> const &other);
+    explicit Point(Point<U, N> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
     /// Construct a Point from an Eigen vector.
-    explicit Point(EigenVector const &vector) : Super(vector) {}
+    explicit Point(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Extent.
-    explicit Point(Extent<T, N> const &other) : Super(other.asEigen()) {}
+    explicit Point(Extent<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(other.asEigen()) {}
 
-    void swap(Point &other) { this->_swap(other); }
+    void swap(Point &other) noexcept { this->_swap(other); }
 };
 
 /**
@@ -198,7 +215,7 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct a Point with all elements set to the same scalar value.
-    explicit Point(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Point(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     Point(Point const &) = default;
     Point(Point &&) = default;
@@ -215,27 +232,31 @@ public:
      *  it lies on (assuming the floating point origin is the center of the first pixel).
      */
     template <typename U>
-    explicit Point(Point<U, 2> const &other);
+    explicit Point(Point<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
     /// Construct a Point from an Eigen vector.
-    explicit Point(EigenVector const &vector) : Super(vector) {}
+    explicit Point(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Extent.
-    explicit Point(Extent<T, 2> const &other) : Super(other.asEigen()) {}
+    explicit Point(Extent<T, 2> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(other.asEigen()) {}
 
     /// Explicit constructor from a pair of doubles.
-    explicit Point(T x, T y) : Super(EigenVector(x, y)) {}
+    explicit Point(T x, T y) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(EigenVector(x, y)) {}
 
     /// Construct from a two-element array.
-    explicit Point(T const xy[2]) : Super(EigenVector(xy[0], xy[1])) {}
+    explicit Point(T const xy[2]) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xy[0], xy[1])) {}
 
     /// Construct from a std::pair.
-    explicit Point(std::pair<T, T> const &xy) : Super(EigenVector(xy.first, xy.second)) {}
+    explicit Point(std::pair<T, T> const &xy) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xy.first, xy.second)) {}
 
     /// Construct from std::tuple.
-    explicit Point(std::tuple<T, T> const &xy) : Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
+    explicit Point(std::tuple<T, T> const &xy) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(std::get<0>(xy), std::get<1>(xy))) {}
 
-    void swap(Point &other) { this->_swap(other); }
+    void swap(Point &other) noexcept { this->_swap(other); }
 };
 
 /**
@@ -251,7 +272,7 @@ public:
     typedef typename Super::EigenVector EigenVector;
 
     /// Construct a Point with all elements set to the same scalar value.
-    explicit Point(T val = static_cast<T>(0)) : Super(val) {}
+    explicit Point(T val = static_cast<T>(0)) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(val) {}
 
     Point(Point const &) = default;
     Point(Point &&) = default;
@@ -268,25 +289,28 @@ public:
      *  it lies on (assuming the floating point origin is the center of the first pixel).
      */
     template <typename U>
-    explicit Point(Point<U, 3> const &other);
+    explicit Point(Point<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>);
 
     /// Construct a Point from an Eigen vector.
-    explicit Point(EigenVector const &vector) : Super(vector) {}
+    explicit Point(EigenVector const &vector) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) : Super(vector) {}
 
     /// Explicit constructor from Extent.
-    explicit Point(Extent<T, 3> const &other) : Super(other.asEigen()) {}
+    explicit Point(Extent<T, 3> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(other.asEigen()) {}
 
     /// Explicit constructor from a sequence of doubles.
-    explicit Point(T x, T y, T z) : Super(EigenVector(x, y, z)) {}
+    explicit Point(T x, T y, T z) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(x, y, z)) {}
 
     /// Construct from a two-element array.
-    explicit Point(T const xyz[3]) : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
+    explicit Point(T const xyz[3]) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+            : Super(EigenVector(xyz[0], xyz[1], xyz[2])) {}
 
     /// Construct from std::tuple.
-    explicit Point(std::tuple<T, T, T> const &xyz)
+    explicit Point(std::tuple<T, T, T> const &xyz) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
             : Super(EigenVector(std::get<0>(xyz), std::get<1>(xyz), std::get<2>(xyz))) {}
 
-    void swap(Point &other) { this->_swap(other); }
+    void swap(Point &other) noexcept { this->_swap(other); }
 };
 
 // Hash functions
@@ -301,47 +325,47 @@ typedef Point<double, 2> Point2D;
 typedef Point<double, 3> Point3D;
 
 template <int N>
-Point<double, N> operator+(Point<double, N> const &lhs, Extent<int, N> const &rhs) {
+Point<double, N> operator+(Point<double, N> const &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs + Extent<double, N>(rhs);
 }
 
 template <int N>
-Point<double, N> operator+(Extent<int, N> const &rhs, Point<double, N> const &lhs) {
+Point<double, N> operator+(Extent<int, N> const &rhs, Point<double, N> const &lhs) noexcept {
     return Point<double, N>(lhs) + rhs;
 }
 
 template <int N>
-Point<double, N> &operator+=(Point<double, N> &lhs, Extent<int, N> const &rhs) {
+Point<double, N> &operator+=(Point<double, N> &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs += Extent<double, N>(rhs);
 }
 
 template <int N>
-Point<double, N> operator+(Point<int, N> const &lhs, Extent<double, N> const &rhs) {
+Point<double, N> operator+(Point<int, N> const &lhs, Extent<double, N> const &rhs) noexcept {
     return Point<double, N>(lhs) + rhs;
 }
 
 template <int N>
-Point<double, N> operator-(Point<double, N> const &lhs, Extent<int, N> const &rhs) {
+Point<double, N> operator-(Point<double, N> const &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs - Extent<double, N>(rhs);
 }
 
 template <int N>
-Point<double, N> &operator-=(Point<double, N> &lhs, Extent<int, N> const &rhs) {
+Point<double, N> &operator-=(Point<double, N> &lhs, Extent<int, N> const &rhs) noexcept {
     return lhs -= Extent<double, N>(rhs);
 }
 
 template <int N>
-Point<double, N> operator-(Point<int, N> const &lhs, Extent<double, N> const &rhs) {
+Point<double, N> operator-(Point<int, N> const &lhs, Extent<double, N> const &rhs) noexcept {
     return Point<double, N>(lhs) - rhs;
 }
 
 template <int N>
-Extent<double, N> operator-(Point<double, N> const &lhs, Point<int, N> const &rhs) {
+Extent<double, N> operator-(Point<double, N> const &lhs, Point<int, N> const &rhs) noexcept {
     return lhs - Point<double, N>(rhs);
 }
 
 template <int N>
-Extent<double, N> operator-(Point<int, N> const &lhs, Point<double, N> const &rhs) {
+Extent<double, N> operator-(Point<int, N> const &lhs, Point<double, N> const &rhs) noexcept {
     return Point<double, N>(lhs) - rhs;
 }
 

--- a/include/lsst/geom/SpherePoint.h
+++ b/include/lsst/geom/SpherePoint.h
@@ -65,7 +65,7 @@ public:
      *                 interval [-&pi;/2, &pi;/2] radians.
      *
      * @throws pex::exceptions::InvalidParameterError
-     *         Thrown if `latitude` isout of range.
+     *         Thrown if `latitude` is out of range.
      *
      * @exceptsafe Provides strong exception guarantee.
      */
@@ -81,7 +81,7 @@ public:
      * @param units The units of longitude and latitude
      *
      * @throws pex::exceptions::InvalidParameterError
-     *         Thrown if `latitude` isout of range.
+     *         Thrown if `latitude` is out of range.
      *
      * @exceptsafe Provides strong exception guarantee.
      */
@@ -109,12 +109,12 @@ public:
      *
      * @param lonLat The lonLat
      *
-     * @exceptsafe Provides strong exception guarantee.
+     * @exceptsafe Shall not throw exceptions.
      */
-    SpherePoint(sphgeom::LonLat const& lonLat);
+    SpherePoint(sphgeom::LonLat const& lonLat) noexcept;
 
     /// Construct a SpherePoint with "nan" for longitude and latitude
-    SpherePoint();
+    SpherePoint() noexcept;
 
     /**
      * Create a copy of a SpherePoint.
@@ -133,7 +133,7 @@ public:
      */
     SpherePoint(SpherePoint&& other) noexcept;
 
-    ~SpherePoint();
+    ~SpherePoint() noexcept;
 
     /**
      * Overwrite this object with the value of another SpherePoint.
@@ -159,8 +159,10 @@ public:
 
     /**
      * Make SpherePoint implicitly convertible to LonLat
+     *
+     * @exceptsafe Shall not throw exceptions.
      */
-    operator sphgeom::LonLat() const;
+    operator sphgeom::LonLat() const noexcept;
 
     /*
      * Accessors
@@ -194,8 +196,10 @@ public:
      * Return longitude, latitude as a Point2D object
      *
      * @param[in] unit  Units of returned data.
+     *
+     * @exceptsafe Shall not throw exceptions.
      */
-    Point2D getPosition(AngleUnit unit) const;
+    Point2D getPosition(AngleUnit unit) const noexcept;
 
     /**
      * A unit vector representation of this point.

--- a/include/lsst/geom/sphgeomUtils.h
+++ b/include/lsst/geom/sphgeomUtils.h
@@ -33,7 +33,7 @@
 namespace lsst {
 namespace geom {
 
-Eigen::Vector3d asEigen(sphgeom::Vector3d const &vector) {
+Eigen::Vector3d asEigen(sphgeom::Vector3d const &vector) noexcept {
     return Eigen::Vector3d(vector.x(), vector.y(), vector.z());
 }
 

--- a/src/AffineTransform.cc
+++ b/src/AffineTransform.cc
@@ -29,13 +29,13 @@
 namespace lsst {
 namespace geom {
 
-AffineTransform::ParameterVector const AffineTransform::getParameterVector() const {
+AffineTransform::ParameterVector const AffineTransform::getParameterVector() const noexcept {
     ParameterVector r;
     r << (*this)[XX], (*this)[YX], (*this)[XY], (*this)[YY], (*this)[X], (*this)[Y];
     return r;
 }
 
-void AffineTransform::setParameterVector(AffineTransform::ParameterVector const &vector) {
+void AffineTransform::setParameterVector(AffineTransform::ParameterVector const &vector) noexcept {
     (*this)[XX] = vector[XX];
     (*this)[XY] = vector[XY];
     (*this)[X] = vector[X];
@@ -44,7 +44,7 @@ void AffineTransform::setParameterVector(AffineTransform::ParameterVector const 
     (*this)[Y] = vector[Y];
 }
 
-AffineTransform::Matrix const AffineTransform::getMatrix() const {
+AffineTransform::Matrix const AffineTransform::getMatrix() const noexcept {
     Matrix r;
     r << (*this)[XX], (*this)[XY], (*this)[X], (*this)[YX], (*this)[YY], (*this)[Y], 0.0, 0.0, 1.0;
     return r;
@@ -55,7 +55,7 @@ AffineTransform const AffineTransform::invert() const {
     return AffineTransform(inv, -inv(getTranslation()));
 }
 
-AffineTransform::TransformDerivativeMatrix AffineTransform::dTransform(Point2D const &input) const {
+AffineTransform::TransformDerivativeMatrix AffineTransform::dTransform(Point2D const &input) const noexcept {
     TransformDerivativeMatrix r = TransformDerivativeMatrix::Zero();
     r.block<2, 4>(0, 0) = getLinear().dTransform(input);
     r(0, X) = 1.0;
@@ -63,7 +63,7 @@ AffineTransform::TransformDerivativeMatrix AffineTransform::dTransform(Point2D c
     return r;
 }
 
-AffineTransform::TransformDerivativeMatrix AffineTransform::dTransform(Extent2D const &input) const {
+AffineTransform::TransformDerivativeMatrix AffineTransform::dTransform(Extent2D const &input) const noexcept {
     TransformDerivativeMatrix r = TransformDerivativeMatrix::Zero();
     r.block<2, 4>(0, 0) = getLinear().dTransform(input);
     return r;

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -105,16 +105,16 @@ ndarray::View<boost::fusion::vector2<ndarray::index::Range, ndarray::index::Rang
     return ndarray::view(getBeginY(), getEndY())(getBeginX(), getEndX());
 }
 
-bool Box2I::contains(Point2I const& point) const {
+bool Box2I::contains(Point2I const& point) const noexcept {
     return all(point.ge(this->getMin())) && all(point.le(this->getMax()));
 }
 
-bool Box2I::contains(Box2I const& other) const {
+bool Box2I::contains(Box2I const& other) const noexcept {
     return other.isEmpty() ||
            (all(other.getMin().ge(this->getMin())) && all(other.getMax().le(this->getMax())));
 }
 
-bool Box2I::overlaps(Box2I const& other) const {
+bool Box2I::overlaps(Box2I const& other) const noexcept {
     return !(other.isEmpty() || this->isEmpty() || any(other.getMax().lt(this->getMin())) ||
              any(other.getMin().gt(this->getMax())));
 }
@@ -182,7 +182,7 @@ void Box2I::include(Box2I const& other) {
     _dimensions = Extent2I(1) + maximum - _minimum;
 }
 
-void Box2I::clip(Box2I const& other) {
+void Box2I::clip(Box2I const& other) noexcept {
     if (isEmpty()) return;
     if (other.isEmpty()) {
         *this = Box2I();
@@ -206,11 +206,11 @@ void Box2I::clip(Box2I const& other) {
     _dimensions = Extent2I(1) + maximum - _minimum;
 }
 
-bool Box2I::operator==(Box2I const& other) const {
+bool Box2I::operator==(Box2I const& other) const noexcept {
     return other._minimum == this->_minimum && other._dimensions == this->_dimensions;
 }
 
-bool Box2I::operator!=(Box2I const& other) const {
+bool Box2I::operator!=(Box2I const& other) const noexcept {
     return other._minimum != this->_minimum || other._dimensions != this->_dimensions;
 }
 
@@ -227,9 +227,9 @@ double const Box2D::EPSILON = std::numeric_limits<double>::epsilon() * 2;
 
 double const Box2D::INVALID = std::numeric_limits<double>::quiet_NaN();
 
-Box2D::Box2D() : _minimum(INVALID), _maximum(INVALID) {}
+Box2D::Box2D() noexcept : _minimum(INVALID), _maximum(INVALID) {}
 
-Box2D::Box2D(Point2D const& minimum, Point2D const& maximum, bool invert)
+Box2D::Box2D(Point2D const& minimum, Point2D const& maximum, bool invert) noexcept
         : _minimum(minimum), _maximum(maximum) {
     for (int n = 0; n < 2; ++n) {
         if (_minimum[n] == _maximum[n]) {
@@ -246,7 +246,7 @@ Box2D::Box2D(Point2D const& minimum, Point2D const& maximum, bool invert)
     }
 }
 
-Box2D::Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert)
+Box2D::Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert) noexcept
         : _minimum(corner), _maximum(corner + dimensions) {
     for (int n = 0; n < 2; ++n) {
         if (_minimum[n] == _maximum[n]) {
@@ -263,28 +263,28 @@ Box2D::Box2D(Point2D const& corner, Extent2D const& dimensions, bool invert)
     }
 }
 
-Box2D::Box2D(Box2I const& other)
+Box2D::Box2D(Box2I const& other) noexcept
         : _minimum(Point2D(other.getMin()) - Extent2D(0.5)),
           _maximum(Point2D(other.getMax()) + Extent2D(0.5)) {
     if (other.isEmpty()) *this = Box2D();
 }
 
-Box2D Box2D::makeCenteredBox(Point2D const& center, Box2D::Extent const& size) {
+Box2D Box2D::makeCenteredBox(Point2D const& center, Box2D::Extent const& size) noexcept {
     lsst::geom::Point2D corner(center);
     corner.shift(-0.5 * size);
     return lsst::geom::Box2D(corner, size, false);
 }
 
-bool Box2D::contains(Point2D const& point) const {
+bool Box2D::contains(Point2D const& point) const noexcept {
     return all(point.ge(this->getMin())) && all(point.lt(this->getMax()));
 }
 
-bool Box2D::contains(Box2D const& other) const {
+bool Box2D::contains(Box2D const& other) const noexcept {
     return other.isEmpty() ||
            (all(other.getMin().ge(this->getMin())) && all(other.getMax().le(this->getMax())));
 }
 
-bool Box2D::overlaps(Box2D const& other) const {
+bool Box2D::overlaps(Box2D const& other) const noexcept {
     return !(other.isEmpty() || this->isEmpty() || any(other.getMax().le(this->getMin())) ||
              any(other.getMin().ge(this->getMax())));
 }
@@ -326,7 +326,7 @@ void Box2D::flipTB(float yextent) {
     // _dimensions should remain unchanged
 }
 
-void Box2D::include(Point2D const& point) {
+void Box2D::include(Point2D const& point) noexcept {
     if (isEmpty()) {
         _minimum = point;
         _maximum = point;
@@ -344,7 +344,7 @@ void Box2D::include(Point2D const& point) {
     }
 }
 
-void Box2D::include(Box2D const& other) {
+void Box2D::include(Box2D const& other) noexcept {
     if (other.isEmpty()) return;
     if (this->isEmpty()) {
         *this = other;
@@ -362,7 +362,7 @@ void Box2D::include(Box2D const& other) {
     }
 }
 
-void Box2D::clip(Box2D const& other) {
+void Box2D::clip(Box2D const& other) noexcept {
     if (isEmpty()) return;
     if (other.isEmpty()) {
         *this = Box2D();
@@ -384,12 +384,12 @@ void Box2D::clip(Box2D const& other) {
     }
 }
 
-bool Box2D::operator==(Box2D const& other) const {
+bool Box2D::operator==(Box2D const& other) const noexcept {
     return (other.isEmpty() && this->isEmpty()) ||
            (other._minimum == this->_minimum && other._maximum == this->_maximum);
 }
 
-bool Box2D::operator!=(Box2D const& other) const {
+bool Box2D::operator!=(Box2D const& other) const noexcept {
     return !(other.isEmpty() && other.isEmpty()) &&
            (other._minimum != this->_minimum || other._maximum != this->_maximum);
 }

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -93,6 +93,10 @@ Box2I::Box2I(Box2D const& other, EdgeHandlingEnum edgeHandling) : _minimum(), _d
 }
 
 Box2I Box2I::makeCenteredBox(Point2D const& center, Box2I::Extent const& size) {
+    if (!std::isfinite(center[0]) || !std::isfinite(center[1])) {
+        throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, "Cannot make Box2I with non-finite center");
+    }
+
     lsst::geom::Point2D corner(center);
     corner.shift(-0.5 * lsst::geom::Extent2D(size));
     // compensate for Box2I's coordinate conventions (where max = min + size - 1)

--- a/src/CoordinateBase.cc
+++ b/src/CoordinateBase.cc
@@ -28,7 +28,8 @@ namespace geom {
 
 template <typename Derived, typename T, int N>
 bool allclose(CoordinateBase<Derived, T, N> const &a, CoordinateBase<Derived, T, N> const &b, T rtol,
-              T atol) {
+              T atol) noexcept(std::is_nothrow_copy_constructible<T>::value
+                                       &&std::is_nothrow_copy_assignable<T>::value) {
     Eigen::Array<T, N, 1> diff = (a.asEigen().array() - b.asEigen().array()).abs();
     Eigen::Array<T, N, 1> rhs = (0.5 * (a.asEigen().array() + b.asEigen().array())).abs();
     rhs *= rtol;

--- a/src/CoordinateExpr.cc
+++ b/src/CoordinateExpr.cc
@@ -27,7 +27,7 @@ namespace lsst {
 namespace geom {
 
 template <int N>
-CoordinateExpr<N> CoordinateExpr<N>::and_(CoordinateExpr<N> const& other) const {
+CoordinateExpr<N> CoordinateExpr<N>::and_(CoordinateExpr<N> const& other) const noexcept {
     CoordinateExpr r(*this);
     for (int n = 0; n < N; ++n) {
         if (!other[n]) r[n] = false;
@@ -36,7 +36,7 @@ CoordinateExpr<N> CoordinateExpr<N>::and_(CoordinateExpr<N> const& other) const 
 }
 
 template <int N>
-CoordinateExpr<N> CoordinateExpr<N>::or_(CoordinateExpr<N> const& other) const {
+CoordinateExpr<N> CoordinateExpr<N>::or_(CoordinateExpr<N> const& other) const noexcept {
     CoordinateExpr r(*this);
     for (int n = 0; n < N; ++n) {
         if (other[n]) r[n] = true;
@@ -45,7 +45,7 @@ CoordinateExpr<N> CoordinateExpr<N>::or_(CoordinateExpr<N> const& other) const {
 }
 
 template <int N>
-CoordinateExpr<N> CoordinateExpr<N>::not_() const {
+CoordinateExpr<N> CoordinateExpr<N>::not_() const noexcept {
     CoordinateExpr r;
     for (int n = 0; n < N; ++n) {
         if (!this->operator[](n)) r[n] = true;

--- a/src/Extent.cc
+++ b/src/Extent.cc
@@ -27,72 +27,76 @@ namespace lsst {
 namespace geom {
 
 template <typename T, int N>
-Extent<T, N>::Extent(Point<T, N> const &other) : Super(other.asEigen()) {}
+Extent<T, N>::Extent(Point<T, N> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+        : Super(other.asEigen()) {}
 
 // The following two template specializations raise Doxygen warnings and produce no documenation.
 // This is a known Doxygen bug: <https://bugzilla.gnome.org/show_bug.cgi?id=406027>
 /// @cond DOXYGEN_BUG
 template <typename T>
-Extent<T, 2>::Extent(Point<T, 2> const &other) : Super(other.asEigen()) {}
+Extent<T, 2>::Extent(Point<T, 2> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+        : Super(other.asEigen()) {}
 
 template <typename T>
-Extent<T, 3>::Extent(Point<T, 3> const &other) : Super(other.asEigen()) {}
+Extent<T, 3>::Extent(Point<T, 3> const &other) noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE)
+        : Super(other.asEigen()) {}
 /// @endcond
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::eq(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::eq(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] == other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::ne(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::ne(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] != other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::lt(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::lt(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] < other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::le(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::le(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] <= other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::gt(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::gt(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] > other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> ExtentBase<T, N>::ge(Extent<T, N> const &other) const {
+CoordinateExpr<N> ExtentBase<T, N>::ge(Extent<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] >= other[n];
     return r;
 }
 
 template <typename T, int N>
-Point<T, N> ExtentBase<T, N>::asPoint() const {
+Point<T, N> ExtentBase<T, N>::asPoint() const noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
     return Point<T, N>(static_cast<Extent<T, N> const &>(*this));
 }
 
 template <typename T, int N>
-Point<T, N> ExtentBase<T, N>::operator+(Point<T, N> const &other) const {
+Point<T, N> ExtentBase<T, N>::operator+(Point<T, N> const &other) const
+        noexcept(Super::IS_ELEMENT_NOTHROW_COPYABLE) {
     return Point<T, N>(this->_vector + other.asEigen());
 }
 
 template <int N>
-Extent<int, N> truncate(Extent<double, N> const &input) {
+Extent<int, N> truncate(Extent<double, N> const &input) noexcept {
     Extent<int, N> result;
     for (int i = 0; i < N; ++i) {
         result[i] = static_cast<int>(input[i]);
@@ -101,7 +105,7 @@ Extent<int, N> truncate(Extent<double, N> const &input) {
 }
 
 template <int N>
-Extent<int, N> floor(Extent<double, N> const &input) {
+Extent<int, N> floor(Extent<double, N> const &input) noexcept {
     Extent<int, N> result;
     for (int i = 0; i < N; ++i) {
         result[i] = std::floor(input[i]);
@@ -110,7 +114,7 @@ Extent<int, N> floor(Extent<double, N> const &input) {
 }
 
 template <int N>
-Extent<int, N> ceil(Extent<double, N> const &input) {
+Extent<int, N> ceil(Extent<double, N> const &input) noexcept {
     Extent<int, N> result;
     for (int i = 0; i < N; ++i) {
         result[i] = std::ceil(input[i]);

--- a/src/LinearTransform.cc
+++ b/src/LinearTransform.cc
@@ -29,13 +29,13 @@
 namespace lsst {
 namespace geom {
 
-LinearTransform::ParameterVector const LinearTransform::getParameterVector() const {
+LinearTransform::ParameterVector const LinearTransform::getParameterVector() const noexcept {
     ParameterVector r;
     r << (*this)[XX], (*this)[YX], (*this)[XY], (*this)[YY];
     return r;
 }
 
-void LinearTransform::setParameterVector(LinearTransform::ParameterVector const& vector) {
+void LinearTransform::setParameterVector(LinearTransform::ParameterVector const& vector) noexcept {
     (*this)[XX] = vector[XX];
     (*this)[XY] = vector[XY];
     (*this)[YX] = vector[YX];
@@ -56,7 +56,7 @@ double LinearTransform::computeDeterminant() const {
     return m(0, 0) * m(1, 1) - m(0, 1) * m(1, 0);
 }
 
-LinearTransform::TransformDerivativeMatrix LinearTransform::dTransform(Point2D const& input) const {
+LinearTransform::TransformDerivativeMatrix LinearTransform::dTransform(Point2D const& input) const noexcept {
     TransformDerivativeMatrix r = TransformDerivativeMatrix::Zero();
     r(0, XX) = input.getX();
     r(0, XY) = input.getY();

--- a/src/LinearTransform.cc
+++ b/src/LinearTransform.cc
@@ -51,10 +51,7 @@ LinearTransform const LinearTransform::invert() const {
     return LinearTransform(inv);
 }
 
-double LinearTransform::computeDeterminant() const {
-    Eigen::MatrixXd const& m = getMatrix();
-    return m(0, 0) * m(1, 1) - m(0, 1) * m(1, 0);
-}
+double LinearTransform::computeDeterminant() const noexcept { return getMatrix().determinant(); }
 
 LinearTransform::TransformDerivativeMatrix LinearTransform::dTransform(Point2D const& input) const noexcept {
     TransformDerivativeMatrix r = TransformDerivativeMatrix::Zero();

--- a/src/Point.cc
+++ b/src/Point.cc
@@ -50,7 +50,7 @@ struct PointSpecialized<double> {
 
 template <typename T, int N>
 template <typename U>
-Point<T, N>::Point(Point<U, N> const &other) : Super() {
+Point<T, N>::Point(Point<U, N> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) : Super() {
     for (int n = 0; n < N; ++n) {
         this->_vector[n] = detail::PointSpecialized<T>::template convert<U>(other[n]);
     }
@@ -58,7 +58,7 @@ Point<T, N>::Point(Point<U, N> const &other) : Super() {
 
 template <typename T>
 template <typename U>
-Point<T, 2>::Point(Point<U, 2> const &other) : Super() {
+Point<T, 2>::Point(Point<U, 2> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) : Super() {
     for (int n = 0; n < 2; ++n) {
         this->_vector[n] = detail::PointSpecialized<T>::template convert<U>(other[n]);
     }
@@ -66,49 +66,49 @@ Point<T, 2>::Point(Point<U, 2> const &other) : Super() {
 
 template <typename T>
 template <typename U>
-Point<T, 3>::Point(Point<U, 3> const &other) : Super() {
+Point<T, 3>::Point(Point<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T, U>) : Super() {
     for (int n = 0; n < 3; ++n) {
         this->_vector[n] = detail::PointSpecialized<T>::template convert<U>(other[n]);
     }
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::eq(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::eq(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] == other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::ne(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::ne(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] != other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::lt(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::lt(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] < other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::le(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::le(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] <= other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::gt(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::gt(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] > other[n];
     return r;
 }
 
 template <typename T, int N>
-CoordinateExpr<N> PointBase<T, N>::ge(Point<T, N> const &other) const {
+CoordinateExpr<N> PointBase<T, N>::ge(Point<T, N> const &other) const noexcept {
     CoordinateExpr<N> r;
     for (int n = 0; n < N; ++n) r[n] = this->_vector[n] >= other[n];
     return r;

--- a/src/SpherePoint.cc
+++ b/src/SpherePoint.cc
@@ -90,7 +90,7 @@ SpherePoint::SpherePoint(sphgeom::Vector3d const& vector) {
     _set(unitVector);
 }
 
-SpherePoint::SpherePoint(sphgeom::LonLat const& lonLat)
+SpherePoint::SpherePoint(sphgeom::LonLat const& lonLat) noexcept
         : SpherePoint(lonLat.getLon().asRadians(), lonLat.getLat().asRadians(), radians) {}
 
 void SpherePoint::_set(sphgeom::UnitVector3d const& unitVector) {
@@ -104,7 +104,7 @@ void SpherePoint::_set(sphgeom::UnitVector3d const& unitVector) {
     }
 }
 
-SpherePoint::SpherePoint() : _longitude(nan("")), _latitude(nan("")) {}
+SpherePoint::SpherePoint() noexcept : _longitude(nan("")), _latitude(nan("")) {}
 
 SpherePoint::SpherePoint(SpherePoint const& other) noexcept = default;
 
@@ -114,18 +114,18 @@ SpherePoint& SpherePoint::operator=(SpherePoint const& other) noexcept = default
 
 SpherePoint& SpherePoint::operator=(SpherePoint&& other) noexcept = default;
 
-SpherePoint::operator sphgeom::LonLat() const {
+SpherePoint::operator sphgeom::LonLat() const noexcept {
     return sphgeom::LonLat::fromRadians(getLongitude().asRadians(), getLatitude().asRadians());
 }
 
-SpherePoint::~SpherePoint() = default;
+SpherePoint::~SpherePoint() noexcept = default;
 
 sphgeom::UnitVector3d SpherePoint::getVector() const noexcept {
     return sphgeom::UnitVector3d::fromNormalized(cos(_longitude) * cos(_latitude),
                                                  sin(_longitude) * cos(_latitude), sin(_latitude));
 }
 
-Point2D SpherePoint::getPosition(AngleUnit unit) const {
+Point2D SpherePoint::getPosition(AngleUnit unit) const noexcept {
     return Point2D(getLongitude().asAngularUnits(unit), getLatitude().asAngularUnits(unit));
 }
 


### PR DESCRIPTION
This PR adds `noexcept` specifiers to most functions and methods in `lsst::geom`. I have omitted these specifiers in a couple of key cases:
- any method that directly or indirectly uses dynamic memory allocation, or where it might be reasonable to want that in the future. This includes methods that return `vector` or `string` by value.
- any method that could in principle take an invalid input (e.g., anything that takes an index) has been left potentially throwing
- many of the methods in the `Coordinate` hierarchy, such as `Point::getSquaredNorm`, are in principle `noexcept` but currently have a potentially throwing implementation. I've left these methods unmarked to avoid leaking implementation details.

The exception specs for classes that use Eigen are based on its policy that Eigen classes only throw `bad_alloc`, and handle all other failure modes using `assert`. I don't know if we want to relax this to allow for non-Eigen implementations in the future.

Note that we could simplify the exception specs for `CoordinateBase` quite a bit by using a `static_assert` to force it to use statically allocated Eigen vectors. However, there are plausible coordinate types (e.g., `std::complex`) that are not nothrow-copyable, so most `CoordinateBase` and subclass methods would still be conditionally `noexcept` depending on `T`.