### PR TITLE
DM-15139: Rename invert() and getInverse() to inverted()

### DIFF
--- a/include/lsst/geom/AffineTransform.h
+++ b/include/lsst/geom/AffineTransform.h
@@ -112,12 +112,15 @@ public:
     AffineTransform(AffineTransform &&) noexcept = default;
     ~AffineTransform() noexcept = default;
 
+    //@{
     /**
      * Return the inverse transform
      *
-     * @throws lsst::geom::SingularTransformException is not invertible
+     * @throws lsst::geom::SingularTransformException if not invertible
      */
-    AffineTransform const invert() const;
+    AffineTransform const inverted() const;
+    AffineTransform const invert() const { return inverted(); };
+    //@}
 
     /** Whether the transform is a no-op. */
     bool isIdentity() const noexcept { return getMatrix().isIdentity(); }

--- a/include/lsst/geom/LinearTransform.h
+++ b/include/lsst/geom/LinearTransform.h
@@ -154,12 +154,17 @@ public:
     double& operator[](int i) { return _matrix(i % 2, i / 2); }
     double const& operator[](int i) const { return const_cast<Matrix&>(_matrix)(i % 2, i / 2); }
 
+    //@{
     /**
      * Return the inverse transform.
      *
-     * @throws lsst::geom::SingularTransformException
+     * @deprecated invert is deprecated in favor of inverted
+     *
+     * @throws lsst::geom::SingularTransformException if not invertible
      */
-    LinearTransform const invert() const;
+    LinearTransform const inverted() const;
+    LinearTransform const invert() const { return inverted(); };
+    //@}
 
     /**
      * Return the determinant of the 2x2 matrix

--- a/python/lsst/geom/affineTransform.cc
+++ b/python/lsst/geom/affineTransform.cc
@@ -94,6 +94,7 @@ PYBIND11_MODULE(affineTransform, mod) {
     });
 
     /* Members */
+    cls.def("inverted", &AffineTransform::inverted);
     cls.def("invert", &AffineTransform::invert);
     cls.def("isIdentity", &AffineTransform::isIdentity);
     cls.def("getTranslation", (Extent2D & (AffineTransform::*)()) & AffineTransform::getTranslation);

--- a/python/lsst/geom/linearTransform.cc
+++ b/python/lsst/geom/linearTransform.cc
@@ -78,6 +78,7 @@ PYBIND11_MODULE(linearTransform, mod) {
     cls.def("getParameterVector", &LinearTransform::getParameterVector);
     cls.def("getMatrix",
             (LinearTransform::Matrix const &(LinearTransform::*)() const) & LinearTransform::getMatrix);
+    cls.def("inverted", &LinearTransform::inverted);
     cls.def("invert", &LinearTransform::invert);
     cls.def("computeDeterminant", &LinearTransform::computeDeterminant);
     cls.def("isIdentity", &LinearTransform::isIdentity);

--- a/src/AffineTransform.cc
+++ b/src/AffineTransform.cc
@@ -50,7 +50,7 @@ AffineTransform::Matrix const AffineTransform::getMatrix() const noexcept {
     return r;
 }
 
-AffineTransform const AffineTransform::invert() const {
+AffineTransform const AffineTransform::inverted() const {
     LinearTransform inv(getLinear().invert());
     return AffineTransform(inv, -inv(getTranslation()));
 }

--- a/src/LinearTransform.cc
+++ b/src/LinearTransform.cc
@@ -42,7 +42,7 @@ void LinearTransform::setParameterVector(LinearTransform::ParameterVector const&
     (*this)[YY] = vector[YY];
 }
 
-LinearTransform const LinearTransform::invert() const {
+LinearTransform const LinearTransform::inverted() const {
     Eigen::FullPivLU<Matrix> lu(getMatrix());
     if (!lu.isInvertible()) {
         throw LSST_EXCEPT(SingularTransformException, "Could not compute LinearTransform inverse");


### PR DESCRIPTION
The `invert` method of `LinearTransform` and `AffineTransform`
implies in-place operation, which is not the case. So provide
new `inverted` methods that do the same thing, make `invert`
call those, and document `invert` as deprecated.