### PR TITLE
DM-9933: Add C++11 inheritance safeguards to afw

### DIFF
--- a/include/lsst/geom/AffineTransform.h
+++ b/include/lsst/geom/AffineTransform.h
@@ -72,7 +72,7 @@ namespace geom {
  *  The 2x2 upper left corner of @f$ \mathbf{M} @f$ is the linear part of the transform is simply the
  *  Jacobian of the mapping between @f$(x_i,y_i)@f$ and @f$(x_f,y_f)@f$.
  */
-class AffineTransform {
+class AffineTransform final {
 public:
     enum Parameters { XX = 0, YX = 1, XY = 2, YY = 3, X = 4, Y = 5 };
 

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -51,7 +51,7 @@ class Box2D;
  *  Box2I sets the minimum point to the origin for an empty box, and returns -1 for both
  *  elements of the maximum point in that case.
  */
-class Box2I {
+class Box2I final {
 public:
     typedef Point2I Point;
     typedef Extent2I Extent;
@@ -288,7 +288,7 @@ private:
  *  emptiness would have been necessary anyhow, so there was little to gain in
  *  using the minimum > maximum condition to denote an empty box, as was used in Box2I.
  */
-class Box2D {
+class Box2D final {
 public:
     typedef Point2D Point;
     typedef Extent2D Extent;

--- a/include/lsst/geom/LinearTransform.h
+++ b/include/lsst/geom/LinearTransform.h
@@ -66,7 +66,7 @@ LSST_EXCEPTION_TYPE(SingularTransformException, lsst::pex::exceptions::RuntimeEr
  *  @f]
  *  evaluated at @f$(x_i,y_i)@f$.
  */
-class LinearTransform {
+class LinearTransform final {
 public:
     enum Parameters { XX = 0, YX = 1, XY = 2, YY = 3 };
 


### PR DESCRIPTION
This PR adds `final` to classes that were not intended to be used with inheritence, as judged by the following criteria:
* the class is not a sub- or superclass of another class,
* the class contains no virtual methods (in particular, no virtual destructor), and
* the class contains no protected methods

Note that there was no need to add `override` to `geom`, because none of the classes (not even `CoordinateBase`) use virtual methods.