### PR TITLE
DM-9938: Make some afw types hashable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ doc/doxygen.conf
 examples/transform
 tests/.tests
 tests/.cache
+tests/test_angle
+tests/test_box
 tests/test_polynomials
 tests/test_coordinates
 tests/test_spherePoint

--- a/include/lsst/geom/Angle.h
+++ b/include/lsst/geom/Angle.h
@@ -94,6 +94,9 @@ public:
      */
     constexpr bool operator==(AngleUnit const& rhs) const noexcept;
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept { return std::hash<double>()(_val); }
+
 private:
     double _val;
 };
@@ -271,6 +274,9 @@ public:
 
 #undef ANGLE_COMP
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept { return std::hash<double>()(_val); }
+
 private:
     double _val;
 };
@@ -444,5 +450,21 @@ inline Angle Angle::separation(Angle const& other) const noexcept { return (*thi
 
 }  // namespace geom
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::geom::AngleUnit> {
+    using argument_type = lsst::geom::AngleUnit;
+    using result_type = size_t;
+    size_t operator()(argument_type const& x) const noexcept { return x.hash_value(); }
+};
+
+template <>
+struct hash<lsst::geom::Angle> {
+    using argument_type = lsst::geom::Angle;
+    using result_type = size_t;
+    size_t operator()(argument_type const& x) const noexcept { return x.hash_value(); }
+};
+}  // namespace std
 
 #endif  // if !defined(LSST_GEOM_ANGLE_H)

--- a/include/lsst/geom/Box.h
+++ b/include/lsst/geom/Box.h
@@ -252,6 +252,9 @@ public:
      */
     bool operator!=(Box2I const& other) const noexcept;
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /**
      * Get the corner points
      *
@@ -492,6 +495,9 @@ public:
      */
     bool operator!=(Box2D const& other) const noexcept;
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /**
      * Get the corner points
      *
@@ -527,5 +533,21 @@ std::ostream& operator<<(std::ostream& os, Box2D const& box);
 
 }  // namespace geom
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::geom::Box2I> {
+    using argument_type = lsst::geom::Box2I;
+    using result_type = size_t;
+    size_t operator()(argument_type const& x) const noexcept { return x.hash_value(); }
+};
+
+template <>
+struct hash<lsst::geom::Box2D> {
+    using argument_type = lsst::geom::Box2D;
+    using result_type = size_t;
+    size_t operator()(argument_type const& x) const noexcept { return x.hash_value(); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/geom/Extent.h
+++ b/include/lsst/geom/Extent.h
@@ -389,6 +389,10 @@ Extent<T, 3>::Extent(Point<U, 3> const &other) noexcept(IS_NOTHROW_CONVERTIBLE<T
     this->setZ(static_cast<T>(other.getZ()));
 };
 
+// Hash functions
+template <typename T, int N>
+std::size_t hash_value(Extent<T, N> const &extent) noexcept;
+
 typedef Extent<int, 2> ExtentI;
 typedef Extent<int, 2> Extent2I;
 typedef Extent<int, 3> Extent3I;
@@ -489,5 +493,14 @@ Extent<double, N> operator-(Extent<int, N> const &lhs, Extent<double, N> const &
 
 }  // namespace geom
 }  // namespace lsst
+
+namespace std {
+template <typename T, int N>
+struct hash<lsst::geom::Extent<T, N>> {
+    using argument_type = lsst::geom::Extent<T, N>;
+    using result_type = std::size_t;
+    result_type operator()(argument_type const &x) const noexcept { return lsst::geom::hash_value(x); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/geom/Point.h
+++ b/include/lsst/geom/Point.h
@@ -315,7 +315,7 @@ public:
 
 // Hash functions
 template <typename T, int N>
-std::size_t hash_value(Point<T, N> const &point);
+std::size_t hash_value(Point<T, N> const &point) noexcept;
 
 typedef Point<int, 2> PointI;
 typedef Point<int, 2> Point2I;
@@ -371,5 +371,14 @@ Extent<double, N> operator-(Point<int, N> const &lhs, Point<double, N> const &rh
 
 }  // namespace geom
 }  // namespace lsst
+
+namespace std {
+template <typename T, int N>
+struct hash<lsst::geom::Point<T, N>> {
+    using argument_type = lsst::geom::Point<T, N>;
+    using result_type = std::size_t;
+    result_type operator()(argument_type const &x) const noexcept { return lsst::geom::hash_value(x); }
+};
+}  // namespace std
 
 #endif

--- a/include/lsst/geom/SpherePoint.h
+++ b/include/lsst/geom/SpherePoint.h
@@ -285,6 +285,9 @@ public:
      */
     bool operator!=(SpherePoint const& other) const noexcept;
 
+    /// Return a hash of this object.
+    std::size_t hash_value() const noexcept;
+
     /**
      * Orientation at this point of the great circle arc to another point.
      *
@@ -407,5 +410,14 @@ std::ostream& operator<<(std::ostream& os, SpherePoint const& point);
 
 }  // namespace geom
 }  // namespace lsst
+
+namespace std {
+template <>
+struct hash<lsst::geom::SpherePoint> {
+    using argument_type = lsst::geom::SpherePoint;
+    using result_type = size_t;
+    size_t operator()(argument_type const& x) const noexcept { return x.hash_value(); }
+};
+}  // namespace std
 
 #endif /* LSST_GEOM_SPHEREPOINT_H_ */

--- a/src/Box.cc
+++ b/src/Box.cc
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <limits>
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/geom/Box.h"
 
 namespace lsst {
@@ -218,6 +219,11 @@ bool Box2I::operator!=(Box2I const& other) const noexcept {
     return other._minimum != this->_minimum || other._dimensions != this->_dimensions;
 }
 
+std::size_t Box2I::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(17, _minimum, _dimensions);
+}
+
 std::vector<Point2I> Box2I::getCorners() const {
     std::vector<Point2I> retVec;
     retVec.push_back(getMin());
@@ -396,6 +402,16 @@ bool Box2D::operator==(Box2D const& other) const noexcept {
 bool Box2D::operator!=(Box2D const& other) const noexcept {
     return !(other.isEmpty() && other.isEmpty()) &&
            (other._minimum != this->_minimum || other._maximum != this->_maximum);
+}
+
+std::size_t Box2D::hash_value() const noexcept {
+    if (isEmpty()) {
+        // All empty boxes are equal and must have equal hashes
+        return 179;
+    } else {
+        // Completely arbitrary seed
+        return utils::hashCombine(17, _minimum, _maximum);
+    }
 }
 
 std::vector<Point2D> Box2D::getCorners() const {

--- a/src/Extent.cc
+++ b/src/Extent.cc
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/geom/CoordinateBase.h"
 #include "lsst/geom/Point.h"
 #include "lsst/geom/Extent.h"
@@ -122,6 +123,13 @@ Extent<int, N> ceil(Extent<double, N> const &input) noexcept {
     return result;
 }
 
+template <typename T, int N>
+std::size_t hash_value(Extent<T, N> const &extent) noexcept {
+    std::size_t result = 0;     // Completely arbitrary seed
+    for (int n = 0; n < N; ++n) result = utils::hashCombine(result, extent[n]);
+    return result;
+}
+
 #ifndef DOXYGEN
 
 template class ExtentBase<int, 2>;
@@ -143,6 +151,11 @@ template Extent<int, 2> floor(Extent<double, 2> const &);
 template Extent<int, 3> floor(Extent<double, 3> const &);
 template Extent<int, 2> ceil(Extent<double, 2> const &);
 template Extent<int, 3> ceil(Extent<double, 3> const &);
+
+template std::size_t hash_value(Extent<int, 2> const &extent) noexcept;
+template std::size_t hash_value(Extent<int, 3> const &extent) noexcept;
+template std::size_t hash_value(Extent<double, 2> const &extent) noexcept;
+template std::size_t hash_value(Extent<double, 3> const &extent) noexcept;
 
 #endif  // !DOXYGEN
 

--- a/src/Point.cc
+++ b/src/Point.cc
@@ -115,8 +115,8 @@ CoordinateExpr<N> PointBase<T, N>::ge(Point<T, N> const &other) const noexcept {
 }
 
 template <typename T, int N>
-std::size_t hash_value(Point<T, N> const &point) {
-    std::size_t result = 0;
+std::size_t hash_value(Point<T, N> const &point) noexcept {
+    std::size_t result = 0;     // Completely arbitrary seed
     for (int n = 0; n < N; ++n) result = utils::hashCombine(result, point[n]);
     return result;
 }

--- a/src/SpherePoint.cc
+++ b/src/SpherePoint.cc
@@ -25,6 +25,7 @@
 
 #include "Eigen/Geometry"
 
+#include "lsst/utils/hashCombine.h"
 #include "lsst/geom/SpherePoint.h"
 #include "lsst/geom/sphgeomUtils.h"
 #include "lsst/pex/exceptions.h"
@@ -149,6 +150,11 @@ bool SpherePoint::operator==(SpherePoint const& other) const noexcept {
 }
 
 bool SpherePoint::operator!=(SpherePoint const& other) const noexcept { return !(*this == other); }
+
+std::size_t SpherePoint::hash_value() const noexcept {
+    // Completely arbitrary seed
+    return utils::hashCombine(17, _longitude, _latitude);
+}
 
 Angle SpherePoint::bearingTo(SpherePoint const& other) const {
     Angle const deltaLon = other.getLongitude() - this->getLongitude();

--- a/tests/test_angle.cc
+++ b/tests/test_angle.cc
@@ -1,0 +1,45 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE AngleCpp
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#include "boost/test/unit_test.hpp"
+#pragma clang diagnostic pop
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Angle.h"
+
+namespace lsst {
+namespace geom {
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<Angle>();
+    utils::assertHashesEqual(0.0 * radians, 0.0 * degrees);
+
+    utils::assertValidHash<AngleUnit>();
+    utils::assertHashesEqual(degrees, AngleUnit(PI / 180.0));
+}
+
+}  // namespace geom
+}  // namespace lsst

--- a/tests/test_box.cc
+++ b/tests/test_box.cc
@@ -1,0 +1,60 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE BoxCpp
+
+#include "boost/test/unit_test.hpp"
+
+#include "lsst/utils/tests.h"
+
+#include "lsst/geom/Box.h"
+
+/*
+ * Unit tests for C++-only functionality in Box2I and Box2D.
+ *
+ * See test_box.py for remaining unit tests.
+ */
+namespace lsst {
+namespace geom {
+
+BOOST_AUTO_TEST_CASE(Box2IHash) {
+    using Int = Box2I::Element;
+    using Point = Box2I::Point;
+
+    utils::assertValidHash<Box2I>();
+    utils::assertHashesEqual(Box2I(Point(0, 0), Point(24, 200)), Box2I(Point(0, 0), Extent2I(25, 201)));
+    utils::assertHashesEqual(Box2I(), Box2I(Point(24, 200), Point(0, 0), false));
+}
+
+BOOST_AUTO_TEST_CASE(Box2DHash) {
+    using Real = Box2D::Element;
+    using Point = Box2D::Point;
+    static const Real nan = std::numeric_limits<Real>::quiet_NaN();
+
+    utils::assertValidHash<Box2D>();
+    utils::assertHashesEqual(Box2D(Point(0, 0), Point(24, 20.5)), Box2D(Point(0, 0), Extent2D(24, 20.5)));
+    utils::assertHashesEqual(Box2D(), Box2D(Point(24, 20.5), Point(0, 0), false));
+    utils::assertHashesEqual(Box2D(), Box2D(Point(nan), Point(42.0, 52.0)));
+}
+
+}  // namespace geom
+}  // namespace lsst

--- a/tests/test_coordinates.cc
+++ b/tests/test_coordinates.cc
@@ -20,15 +20,20 @@
  */
 
 #define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE ellipses
+#define BOOST_TEST_MODULE coordinates
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 #include "boost/test/unit_test.hpp"
 #pragma clang diagnostic pop
 #include "boost/format.hpp"
 
+#include "lsst/utils/tests.h"
+
 #include "lsst/geom/Point.h"
 #include "lsst/geom/Extent.h"
+
+namespace lsst {
+namespace geom {
 
 // Most Extent and Point operators are tested in coordinates.py in Python, but
 // division of negative integers has different behavior in the two languages,
@@ -40,3 +45,23 @@ BOOST_AUTO_TEST_CASE(Operators) {
     e2 /= 3;
     BOOST_CHECK_EQUAL(e2, lsst::geom::Extent2I(e1.getX() / 3, e1.getY() / 3));
 }
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<Extent2I>();
+    utils::assertValidHash<Extent2D>();
+    utils::assertValidHash<Extent3I>();
+    utils::assertValidHash<Extent3D>();
+    utils::assertValidHash<Point2I>();
+    utils::assertValidHash<Point2D>();
+    utils::assertValidHash<Point3I>();
+    utils::assertValidHash<Point3D>();
+
+    utils::assertHashesEqual(Extent2I(12, -23), Extent2I(12, -23));
+    utils::assertHashesEqual(Extent2I(0, 0), Extent2I());
+
+    utils::assertHashesEqual(Point2D(3.4, -2.7), Point2D(3.4, -2.7));
+    utils::assertHashesEqual(Point2D(0, 0), Point2D());
+}
+
+}  // namespace geom
+}  // namespace lsst

--- a/tests/test_spherePoint.cc
+++ b/tests/test_spherePoint.cc
@@ -24,6 +24,8 @@
 
 #include "boost/test/unit_test.hpp"
 
+#include "lsst/utils/tests.h"
+
 #include "lsst/sphgeom/Vector3d.h"
 #include "lsst/geom/SpherePoint.h"
 #include "lsst/pex/exceptions/Exception.h"
@@ -31,7 +33,7 @@
 /*
  * Unit tests for C++-only functionality in SpherePoint.
  *
- * See testSpherePoint.py for remaining unit tests.
+ * See test_spherePoint.py for remaining unit tests.
  */
 namespace lsst {
 namespace geom {
@@ -125,6 +127,15 @@ BOOST_AUTO_TEST_CASE(getItemError) {
 }
 
 // TODO: add a test for propagation of ostream errors
+
+BOOST_AUTO_TEST_CASE(Hash) {
+    utils::assertValidHash<SpherePoint>();
+
+    utils::assertHashesEqual(SpherePoint(0 * degrees, -24 * degrees),
+                             SpherePoint(0 * degrees, -24 * degrees));
+    utils::assertHashesEqual(SpherePoint(HALFPI * radians, 0.0 * radians),
+                             SpherePoint(sphgeom::Vector3d(0, 1, 0)));
+}
 
 }  // namespace geom
 }  // namespace lsst


### PR DESCRIPTION
This PR switches `Point`'s existing hash to use `std::hash`, and adds hash support to all value types in `geom` (defined as supporting `operator==`).

This PR requires lsst/utils#65.