### PR TITLE
DM-15417: Remove deprecated method `invert`

### DIFF
--- a/include/lsst/geom/AffineTransform.h
+++ b/include/lsst/geom/AffineTransform.h
@@ -119,7 +119,6 @@ public:
      * @throws lsst::geom::SingularTransformException if not invertible
      */
     AffineTransform const inverted() const;
-    AffineTransform const invert() const { return inverted(); };
     //@}
 
     /** Whether the transform is a no-op. */

--- a/include/lsst/geom/LinearTransform.h
+++ b/include/lsst/geom/LinearTransform.h
@@ -163,7 +163,6 @@ public:
      * @throws lsst::geom::SingularTransformException if not invertible
      */
     LinearTransform const inverted() const;
-    LinearTransform const invert() const { return inverted(); };
     //@}
 
     /**

--- a/include/lsst/geom/polynomials/Scaling1d.h
+++ b/include/lsst/geom/polynomials/Scaling1d.h
@@ -89,7 +89,7 @@ public:
     /**
      *  Invert the transform.
      *
-     *  If `r = t.invert()`, then `r.applyForward(x)` is equivalent to
+     *  If `r = t.inverted()`, then `r.applyForward(x)` is equivalent to
      *  `t.applyInverse(x)` and `r.applyInverse(y)` is equivalent to
      *  `t.applyForward(y)`.
      */

--- a/include/lsst/geom/polynomials/Scaling2d.h
+++ b/include/lsst/geom/polynomials/Scaling2d.h
@@ -82,7 +82,7 @@ public:
     /**
      *  Invert the transform.
      *
-     *  If `r = t.invert()`, then `r.applyForward(p)` is equivalent to
+     *  If `r = t.inverted()`, then `r.applyForward(p)` is equivalent to
      *  `t.applyInverse(p)` and `r.applyInverse(q)` is equivalent to
      *  `t.applyForward(q)`.
      */

--- a/python/lsst/geom/_AffineTransform.cc
+++ b/python/lsst/geom/_AffineTransform.cc
@@ -97,7 +97,6 @@ void wrapAffineTransform(utils::python::WrapperCollection & wrappers) {
 
             /* Members */
             cls.def("inverted", &AffineTransform::inverted);
-            cls.def("invert", &AffineTransform::invert);
             cls.def("isIdentity", &AffineTransform::isIdentity);
             cls.def("getTranslation", (Extent2D & (AffineTransform::*)()) & AffineTransform::getTranslation);
             cls.def("getLinear", (LinearTransform & (AffineTransform::*)()) & AffineTransform::getLinear);

--- a/python/lsst/geom/_LinearTransform.cc
+++ b/python/lsst/geom/_LinearTransform.cc
@@ -83,7 +83,6 @@ void wrapLinearTransform(utils::python::WrapperCollection & wrappers) {
             cls.def("getMatrix",
                     py::overload_cast<>(& LinearTransform::getMatrix, py::const_));
             cls.def("inverted", &LinearTransform::inverted);
-            cls.def("invert", &LinearTransform::invert);
             cls.def("computeDeterminant", &LinearTransform::computeDeterminant);
             cls.def("isIdentity", &LinearTransform::isIdentity);
 

--- a/src/AffineTransform.cc
+++ b/src/AffineTransform.cc
@@ -51,7 +51,7 @@ AffineTransform::Matrix const AffineTransform::getMatrix() const noexcept {
 }
 
 AffineTransform const AffineTransform::inverted() const {
-    LinearTransform inv(getLinear().invert());
+    LinearTransform inv(getLinear().inverted());
     return AffineTransform(inv, -inv(getTranslation()));
 }
 


### PR DESCRIPTION
Use `inverted` instead.