### PR TITLE
DM-17566: Formally deprecate discouraged C++ afw/geom components

### DIFF
--- a/include/lsst/geom/LinearTransform.h
+++ b/include/lsst/geom/LinearTransform.h
@@ -154,16 +154,12 @@ public:
     double& operator[](int i) { return _matrix(i % 2, i / 2); }
     double const& operator[](int i) const { return const_cast<Matrix&>(_matrix)(i % 2, i / 2); }
 
-    //@{
     /**
      * Return the inverse transform.
-     *
-     * @deprecated invert is deprecated in favor of inverted
      *
      * @throws lsst::geom::SingularTransformException if not invertible
      */
     LinearTransform const inverted() const;
-    //@}
 
     /**
      * Return the determinant of the 2x2 matrix


### PR DESCRIPTION
This PR removes an outdated comment requesting the deprecation of a method that had already been removed.