### PR TITLE
Resolve documentation markup errors.

### DIFF
--- a/python/lsst/geom/testUtils.py
+++ b/python/lsst/geom/testUtils.py
@@ -64,10 +64,12 @@ def assertAnglesAlmostEqual(testCase, ang0, ang1, maxDiff=0.001*arcseconds,
         maximum difference between the two angles
     ignoreWrap : `bool`
         ignore wrap when comparing the angles?
+
         - if True then wrap is ignored, e.g. 0 and 360 degrees are considered
           equal
         - if False then wrap matters, e.g. 0 and 360 degrees are considered
           different
+
     msg : `str`
         exception message prefix; details of the error are appended after ": "
 


### PR DESCRIPTION
Specifically:

/python/lsst/geom/testUtils.py:docstring of lsst.utils.tests.TestCase.assertAnglesAlmostEqual:26: WARNING: Unexpected indentation.
/python/lsst/geom/testUtils.py:docstring of lsst.utils.tests.TestCase.assertAnglesAlmostEqual:27: WARNING: Block quote ends without a blank line; unexpected unindent.