### PR TITLE
DM-29501: C++17 migration

### DIFF
--- a/python/lsst/geom/_Interval.cc
+++ b/python/lsst/geom/_Interval.cc
@@ -80,7 +80,7 @@ void declareCommonIntervalInterface(PyClass &cls) {
     cls.def_property_readonly("size", &T::getSize);
     cls.def("isEmpty", &T::isEmpty);
     cls.def("contains", py::overload_cast<T const &>(&T::contains, py::const_));
-    cls.def("contains", py::vectorize(static_cast<bool (T::*)(Element) const noexcept>(&T::contains)));
+    cls.def("contains", py::vectorize(static_cast<bool (T::*)(Element) const>(&T::contains)));
     cls.def("__contains__", py::overload_cast<Element>(&T::contains, py::const_));
     cls.def("__contains__", py::overload_cast<T const &>(&T::contains, py::const_));
     cls.def("overlaps", &T::overlaps);


### PR DESCRIPTION
C++17 trips over noexcept in static cast of overloaded function