### PR TITLE
DM-13943: Fix Angle::operator==.

### DIFF
--- a/include/lsst/geom/Angle.h
+++ b/include/lsst/geom/Angle.h
@@ -261,8 +261,11 @@ public:
 
     //@{
     /// Test if two Angles represent the same angle (without wrapping).
-    ANGLE_COMP(==)
-    ANGLE_COMP(!=)
+    // For some reason, isnan can't be used in constexpr
+    bool operator==(const Angle& rhs) const noexcept {
+        return (std::isnan(_val) && std::isnan(rhs._val)) || _val == rhs._val;
+    }
+    bool operator!=(const Angle& rhs) const noexcept { return !(*this == rhs); }
     //@}
     //@{
     /// Compare the sizes of two Angles (without wrapping).

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -59,6 +59,20 @@ class AngleTestCase(lsst.utils.tests.TestCase):
         dd = lsst.geom.Angle(60*60*180*1000, lsst.geom.milliarcseconds)
         self.assertEqual(self.d, dd)
 
+    def testEquals(self):
+        self.assertEqual(0 * lsst.geom.arcminutes, 0 * lsst.geom.arcminutes)
+        self.assertEqual(42 * lsst.geom.degrees, 42 * lsst.geom.degrees)
+        self.assertEqual(np.nan * lsst.geom.radians, np.nan * lsst.geom.radians)
+        self.assertNotEqual(0 * lsst.geom.arcminutes, self.pi)
+
+        # equality must be reflexive
+        self.assertEqual(self.pi, self.pi)
+        self.assertEqual(self.d, self.d)
+        angle = 42 * lsst.geom.degrees
+        self.assertEqual(angle, angle)
+        angle = np.nan * lsst.geom.radians
+        self.assertEqual(angle, angle)
+
     def testArithmetic(self):
         self.assertTrue(lsst.geom.isAngle(self.pi))
         self.assertFalse(lsst.geom.isAngle(self.pi.asRadians()))


### PR DESCRIPTION
This PR fixes a bug in `Angle` that was breaking upstream code, particularly lsst/afw#614 and lsst/obs_base#396. A better solution would have been to forbid `Angle(NaN)`, but NaN values are considered a desirable feature in DM, and retrofitting a ban on invalid objects would require major changes to the `afw`/`meas_*`/`obs_*` codebase.