### PR TITLE
DM-33167: Test and fix __repr__ for Box, Point, and Extent classes.

### DIFF
--- a/python/lsst/geom/_Box.cc
+++ b/python/lsst/geom/_Box.cc
@@ -130,7 +130,7 @@ void wrapBox(utils::python::WrapperCollection & wrappers) {
             cls.def("getCorners", &Box2I::getCorners);
             cls.def("toString", &Box2I::toString);
             cls.def("__repr__", [](Box2I const &self) {
-                return py::str("Box2I(minimum={}, dimensions={})")
+                return py::str("Box2I(corner={}, dimensions={})")
                     .format(py::repr(py::cast(self.getMin())), py::repr(py::cast(self.getDimensions())));
             });
             cls.def("__str__", [](Box2I const &self) {
@@ -235,7 +235,7 @@ void wrapBox(utils::python::WrapperCollection & wrappers) {
             cls.def("getCorners", &Box2D::getCorners);
             cls.def("toString", &Box2D::toString);
             cls.def("__repr__", [](Box2D const &self) {
-                return py::str("Box2D(minimum={}, dimensions={})")
+                return py::str("Box2D(corner={}, dimensions={})")
                     .format(py::repr(py::cast(self.getMin())), py::repr(py::cast(self.getDimensions())));
             });
             cls.def("__str__", [](Box2D const &self) {

--- a/python/lsst/geom/_coordinates.py
+++ b/python/lsst/geom/_coordinates.py
@@ -22,6 +22,8 @@
 __all__ = ["CoordinateExpr", "Extent", "ExtentI", "ExtentD",
            "Point", "PointI", "PointD"]
 
+import math
+
 from lsst.utils import TemplateMeta
 
 from . import _geom
@@ -33,7 +35,7 @@ def _coordinateStr(self):
 
 def _coordinateRepr(self):
     return "{}({})".format(type(self).__name__,
-                           ", ".join("%0.10g" % v for v in self))
+                           ", ".join(f"{v:0.17g}" if math.isfinite(v) else f"float('{v}')" for v in self))
 
 
 def _coordinateReduce(self):

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -104,13 +104,18 @@ class Box2ITestCase(lsst.utils.tests.TestCase):
             # usually sizeof(long).
             self.assertLess(box.getWidth(), 0)
 
-    def testRepr(self):
-        box = geom.Box2I()
-        repr_str = box.__repr__()
-        self.assertTrue(repr_str.startswith('Box2I'))
-        box = geom.Box2D()
-        repr_str = box.__repr__()
-        self.assertTrue(repr_str.startswith('Box2D'))
+    def test_Box2I_repr(self):
+        from lsst.geom import Box2I, Point2I, Extent2I
+        self.assertEqual(eval(repr(Box2I())), Box2I())
+        self.assertEqual(eval(repr(Box2I(Point2I(1, 2), Extent2I(3, 4)))),
+                         Box2I(Point2I(1, 2), Extent2I(3, 4)))
+
+    def test_Box2D_repr(self):
+        from lsst.geom import Box2D, Point2D, Extent2D
+        print(repr(Box2D()))
+        self.assertEqual(eval(repr(Box2D())), Box2D())
+        self.assertEqual(eval(repr(Box2D(Point2D(1.0, 2.0), Extent2D(3.0, 4.0)))),
+                         Box2D(Point2D(1.0, 2.0), Extent2D(3.0, 4.0)))
 
     def testPointExtent(self):
         box = geom.Box2I()

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -113,6 +113,24 @@ class CoordinateTestCase:
             self.assertEqual(type(p1.gt(scalar)), CoordinateExpr)
             self.assertEqual(type(p1.ge(scalar)), CoordinateExpr)
 
+    def test_repr(self):
+        # repr uses unqualified names, so we need to bring them all in
+        # scope for eval(repr(...)) to work.
+        from lsst.geom import (  # noqa: F401
+            Extent2D,
+            Extent2I,
+            Extent3D,
+            Extent3I,
+            Point2D,
+            Point2I,
+            Point3D,
+            Point3I,
+        )
+        for _, cls, rnd in self.classes:
+            p = cls(*rnd())
+            self.assertEqual(eval(repr(p)), p)
+            self.assertEqual(eval(repr(cls())), cls())
+
 
 class PointTestCase(CoordinateTestCase, lsst.utils.tests.TestCase):
     """A test case for Point"""


### PR DESCRIPTION
`eval(repr(...))` now works for these classes, as long as the relevant class symbols are present.